### PR TITLE
build_branch_docs.sh do tags and main branch only

### DIFF
--- a/docs/build_branch_docs.sh
+++ b/docs/build_branch_docs.sh
@@ -4,6 +4,10 @@
 OUTPUT_DIR=$(pwd)/build
 mkdir -p ${OUTPUT_DIR}
 
+# determine the branches from the switcher json (could also list tags instead)
+DOCSVERSIONS=$(python3 -c "import json; print(' '.join([fx['version'] for fx in json.loads(open('./switcher.json').read())]))")
+echo $DOCSVERSIONS
+
 # clone the repo into a temporary place
 REPO=https://github.com/ExCALIBUR-NEPTUNE/NESO-Particles.git
 mkdir /tmp/repo-checkout
@@ -11,8 +15,8 @@ cd /tmp/repo-checkout
 git clone $REPO
 cd NESO-Particles/docs
 
-# checkout each tag and the main branch, build the docs for that version
-for BX in `git tag -l --sort=refname v*` main
+# checkout each version to build and build the docs for that version in tmp
+for BX in $DOCSVERSIONS
 do
     echo $BX
     echo $(pwd)

--- a/docs/build_branch_docs.sh
+++ b/docs/build_branch_docs.sh
@@ -4,10 +4,6 @@
 OUTPUT_DIR=$(pwd)/build
 mkdir -p ${OUTPUT_DIR}
 
-# determine the branches from the switcher json (could also list tags instead)
-BRANCHES=$(python3 -c "import json; print(' '.join([fx['version'] for fx in json.loads(open('./switcher.json').read())]))")
-echo $BRANCHES
-
 # clone the repo into a temporary place
 REPO=https://github.com/ExCALIBUR-NEPTUNE/NESO-Particles.git
 mkdir /tmp/repo-checkout
@@ -15,8 +11,8 @@ cd /tmp/repo-checkout
 git clone $REPO
 cd NESO-Particles/docs
 
-# checkout each version to build and build the docs for that version in tmp
-for BX in $BRANCHES
+# checkout each tag and the main branch, build the docs for that version
+for BX in `git tag -l --sort=refname v*` main
 do
     echo $BX
     echo $(pwd)

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -1,4 +1,4 @@
 breathe
-pydata-sphinx-theme
 GitPython==3.1.29
+pydata-sphinx-theme
 sphinx

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -1,3 +1,4 @@
-sphinx
 breathe
 pydata-sphinx-theme
+GitPython==3.1.29
+sphinx

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -36,6 +36,25 @@ html_theme_options = {
     "show_nav_level": 3
 }
 
+import git
+import json
+
+repo = git.Repo('.')
+tags = sorted(repo.tags, key=lambda t: t.commit.committed_datetime)
+
+def jsonobjectfunc(version):
+    strversion = str(version)
+    urlversion = "https://excalibur-neptune.github.io/NESO-Particles/" + strversion + "/sphinx/html/"
+    return {"version": strversion, "url": urlversion}
+    
+json_contents = [jsonobjectfunc("main")]
+for t in tags:
+    tagobject = jsonobjectfunc(t)
+    json_contents.append(tagobject)
+
+with open('../../switcher.json', 'w') as fh:
+    json.dump(json_contents, fh)
+
 import os
 docs_version = "./docs_version"
 if os.path.exists(docs_version):


### PR DESCRIPTION
Compute the versions.json file on the fly to alleviate need to hard code tags / branches that we want to make docs for.