### PR TITLE
added line to build docs on tag push

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - v*
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Build docs on tag push. Assumes a GH release tag creation is a "push".