### PR TITLE
Feature/particle remove interface

### DIFF
--- a/include/neso_particles.hpp
+++ b/include/neso_particles.hpp
@@ -19,6 +19,7 @@
 #include "particle_dat.hpp"
 #include "particle_group.hpp"
 #include "particle_io.hpp"
+#include "particle_remover.hpp"
 #include "particle_set.hpp"
 #include "particle_spec.hpp"
 #include "profiling.hpp"

--- a/include/particle_group.hpp
+++ b/include/particle_group.hpp
@@ -544,7 +544,7 @@ template <typename... T> inline void ParticleGroup::print(T... args) {
     for (auto &symx : print_spec.syms_int) {
       std::cout << "| " << symx.name << " ";
     }
-    std::cout << "|" << endl;
+    std::cout << "|" << std::endl;
 
     for (int rowx = 0; rowx < nrow; rowx++) {
       for (auto &cx : cell_data_real) {

--- a/include/particle_remover.hpp
+++ b/include/particle_remover.hpp
@@ -1,0 +1,119 @@
+#ifndef _NESO_PARTICLES_PARTICLE_REMOVER
+#define _NESO_PARTICLES_PARTICLE_REMOVER
+
+#include "compute_target.hpp"
+#include "particle_dat.hpp"
+#include "particle_group.hpp"
+#include "typedefs.hpp"
+
+namespace NESO::Particles {
+
+class ParticleRemover {
+private:
+  BufferDeviceHost<INT> dh_remove_count;
+  BufferDevice<INT> d_remove_cells;
+  BufferDevice<INT> d_remove_layers;
+  SYCLTargetSharedPtr sycl_target;
+
+public:
+  /// Disable (implicit) copies.
+  ParticleRemover(const ParticleRemover &st) = delete;
+  /// Disable (implicit) copies.
+  ParticleRemover &operator=(ParticleRemover const &a) = delete;
+
+  ParticleRemover(SYCLTargetSharedPtr sycl_target)
+      : sycl_target(sycl_target), dh_remove_count(sycl_target, 1),
+        d_remove_cells(sycl_target, 1), d_remove_layers(sycl_target, 1) {}
+
+  /**
+   * Remove particles from a ParticleGroup based on a value in a ParticleDat.
+   * For each particle, compares the first value in the ParticleDat with the
+   * passed Key. Removes the particle if the value matches the key.
+   *
+   * @param particle_group ParticleGroup to remove particles from.
+   * @param particle_dat ParticleDat to inspect to determine if particles
+   * should be removed.
+   * @param key Key to compare particle values with for removal.
+   */
+  template <typename T>
+  inline void remove(ParticleGroupSharedPtr particle_group,
+                     ParticleDatSharedPtr<T> particle_dat, const T key) {
+
+    auto pl_iter_range = particle_dat->get_particle_loop_iter_range();
+    auto pl_stride = particle_dat->get_particle_loop_cell_stride();
+    auto pl_npart_cell = particle_dat->get_particle_loop_npart_cell();
+
+    auto k_compare_dat = particle_dat->cell_dat.device_ptr();
+    auto k_key = key;
+
+    // reset the leave count
+    this->dh_remove_count.h_buffer.ptr[0] = 0;
+    this->dh_remove_count.host_to_device();
+    auto k_leave_count = this->dh_remove_count.d_buffer.ptr;
+
+    this->sycl_target->queue
+        .submit([&](sycl::handler &cgh) {
+          cgh.parallel_for<>(
+              sycl::range<1>(pl_iter_range), [=](sycl::id<1> idx) {
+                NESO_PARTICLES_KERNEL_START
+                const INT cellx = NESO_PARTICLES_KERNEL_CELL;
+                const INT layerx = NESO_PARTICLES_KERNEL_LAYER;
+                const T compare_value = k_compare_dat[cellx][0][layerx];
+                // Is this particle is getting removed?
+                if (compare_value == k_key) {
+                  sycl::atomic_ref<INT, sycl::memory_order::relaxed,
+                                   sycl::memory_scope::device>
+                      remove_count_atomic{k_leave_count[0]};
+                  remove_count_atomic.fetch_add(1);
+                }
+                NESO_PARTICLES_KERNEL_END
+              });
+        })
+        .wait_and_throw();
+
+    // read from the device the number of particles to remove
+    this->dh_remove_count.device_to_host();
+    const INT remove_count = this->dh_remove_count.h_buffer.ptr[0];
+    if (remove_count > 0) {
+      // reset the leave count
+      this->dh_remove_count.h_buffer.ptr[0] = 0;
+      this->dh_remove_count.host_to_device();
+      // space to store the cells/layers indices for the removal
+      this->d_remove_cells.realloc_no_copy(remove_count);
+      this->d_remove_layers.realloc_no_copy(remove_count);
+      auto k_remove_cells = this->d_remove_cells.ptr;
+      auto k_remove_layers = this->d_remove_layers.ptr;
+
+      // assemble the remove indices/layers
+      this->sycl_target->queue
+          .submit([&](sycl::handler &cgh) {
+            cgh.parallel_for<>(
+                sycl::range<1>(pl_iter_range), [=](sycl::id<1> idx) {
+                  NESO_PARTICLES_KERNEL_START
+                  const INT cellx = NESO_PARTICLES_KERNEL_CELL;
+                  const INT layerx = NESO_PARTICLES_KERNEL_LAYER;
+                  const T compare_value = k_compare_dat[cellx][0][layerx];
+                  // Is this particle is getting removed?
+                  if (compare_value == k_key) {
+                    sycl::atomic_ref<INT, sycl::memory_order::relaxed,
+                                     sycl::memory_scope::device>
+                        remove_count_atomic{k_leave_count[0]};
+                    const INT index = remove_count_atomic.fetch_add(1);
+                    k_remove_cells[index] = cellx;
+                    k_remove_layers[index] = layerx;
+                  }
+                  NESO_PARTICLES_KERNEL_END
+                });
+          })
+          .wait_and_throw();
+
+      // remove the particles from the particle_group
+      particle_group->remove_particles(static_cast<int>(remove_count),
+                                       k_remove_cells, k_remove_layers);
+    }
+  }
+};
+
+} // namespace NESO::Particles
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,7 +45,7 @@ include(GoogleTest)
 foreach(TEST ${TEST_SRCS})
   get_filename_component(TEST_NAME ${TEST} NAME_WLE)
   message(STATUS "Found test - ${TEST_NAME}")
-  set(TEST_LIST ${TEST_LIST} ${TEST_NAME})
+  set(TEST_LIST ${TEST_LIST} ${TEST})
 
   set(TEST_SOURCES ${TEST_MAIN} ${TEST})
   add_executable(${TEST_NAME} ${TEST_SOURCES})

--- a/test/test_particle_remover.cpp
+++ b/test/test_particle_remover.cpp
@@ -1,0 +1,66 @@
+#include <CL/sycl.hpp>
+#include <gtest/gtest.h>
+#include <neso_particles.hpp>
+#include <random>
+#include <memory>
+
+using namespace NESO::Particles;
+
+TEST(ParticleRemover, remove) {
+
+  const int ndim = 2;
+  std::vector<int> dims(ndim);
+  dims[0] = 4;
+  dims[1] = 8;
+
+  const double cell_extent = 1.0;
+  const int subdivision_order = 2;
+  auto mesh = std::make_shared<CartesianHMesh>(MPI_COMM_WORLD, ndim, dims,
+                                               cell_extent, subdivision_order);
+
+  auto sycl_target =
+      std::make_shared<SYCLTarget>(GPU_SELECTOR, mesh->get_comm());
+
+  auto domain = std::make_shared<Domain>(mesh);
+
+  ParticleSpec particle_spec{ParticleProp(Sym<REAL>("P"), ndim, true),
+                             ParticleProp(Sym<INT>("CELL_ID"), 1, true),
+                             ParticleProp(Sym<INT>("ID"), 1),
+                             ParticleProp(Sym<INT>("REMOVE_FLAG"), 1)
+  };
+
+  auto A = std::make_shared<ParticleGroup>(domain, particle_spec, sycl_target);
+  A->add_particle_dat(ParticleDat(sycl_target, ParticleProp(Sym<REAL>("FOO"), 3),
+                                 domain->mesh->get_cell_count()));
+  
+  const int rank = sycl_target->comm_pair.rank_parent;
+
+  const int N = 10;
+  const int last_keep_index = N / 2 - 1;
+
+  if (rank == 0){
+    std::mt19937 rng_pos(52234234);
+    auto positions =
+        uniform_within_extents(N, ndim, mesh->global_extents, rng_pos);
+
+    ParticleSet initial_distribution(N, particle_spec);
+
+    for (int px = 0; px < N; px++) {
+      for (int dimx = 0; dimx < ndim; dimx++) {
+        initial_distribution[Sym<REAL>("P")][px][dimx] = positions[dimx][px];
+      }
+      initial_distribution[Sym<INT>("CELL_ID")][px][0] = 0;
+      initial_distribution[Sym<INT>("ID")][px][0] = px;
+      
+      const int remove_flag = (px > last_keep_index) ? 1 : 0;
+      initial_distribution[Sym<INT>("REMOVE_FLAG")][px][0] = remove_flag;
+    }
+    A->add_particles(initial_distribution);
+  } else {
+    A->add_particles();
+  }
+
+  mesh->free();
+  A->free();
+}
+

--- a/test/test_particle_remover.cpp
+++ b/test/test_particle_remover.cpp
@@ -1,8 +1,8 @@
 #include <CL/sycl.hpp>
 #include <gtest/gtest.h>
+#include <memory>
 #include <neso_particles.hpp>
 #include <random>
-#include <memory>
 
 using namespace NESO::Particles;
 
@@ -22,23 +22,21 @@ TEST(ParticleRemover, remove) {
       std::make_shared<SYCLTarget>(GPU_SELECTOR, mesh->get_comm());
 
   auto domain = std::make_shared<Domain>(mesh);
+  const int cell_count = domain->mesh->get_cell_count();
 
   ParticleSpec particle_spec{ParticleProp(Sym<REAL>("P"), ndim, true),
                              ParticleProp(Sym<INT>("CELL_ID"), 1, true),
                              ParticleProp(Sym<INT>("ID"), 1),
-                             ParticleProp(Sym<INT>("REMOVE_FLAG"), 1)
-  };
+                             ParticleProp(Sym<INT>("REMOVE_FLAG"), 1)};
 
   auto A = std::make_shared<ParticleGroup>(domain, particle_spec, sycl_target);
-  A->add_particle_dat(ParticleDat(sycl_target, ParticleProp(Sym<REAL>("FOO"), 3),
-                                 domain->mesh->get_cell_count()));
-  
   const int rank = sycl_target->comm_pair.rank_parent;
 
-  const int N = 10;
+  const int N = 2048;
   const int last_keep_index = N / 2 - 1;
 
-  if (rank == 0){
+  // Add some particles and set flag such that roughly half should be removed
+  if (rank == 0) {
     std::mt19937 rng_pos(52234234);
     auto positions =
         uniform_within_extents(N, ndim, mesh->global_extents, rng_pos);
@@ -51,16 +49,38 @@ TEST(ParticleRemover, remove) {
       }
       initial_distribution[Sym<INT>("CELL_ID")][px][0] = 0;
       initial_distribution[Sym<INT>("ID")][px][0] = px;
-      
+
       const int remove_flag = (px > last_keep_index) ? 1 : 0;
       initial_distribution[Sym<INT>("REMOVE_FLAG")][px][0] = remove_flag;
     }
-    A->add_particles(initial_distribution);
-  } else {
-    A->add_particles();
+    A->add_particles_local(initial_distribution);
   }
+
+  A->hybrid_move();
+
+  // create a remover and remove particles
+  auto particle_remover = std::make_shared<ParticleRemover>(sycl_target);
+  particle_remover->remove(A, (*A)[Sym<INT>("REMOVE_FLAG")], 1);
+
+  // check particles were removed
+  int npart_found = 0;
+  for (int cellx = 0; cellx < cell_count; cellx++) {
+
+    auto id = (*A)[Sym<INT>("ID")]->cell_dat.get_cell(cellx);
+
+    for (int rowx = 0; rowx < id->nrow; rowx++) {
+      const INT px = (*id)[0][rowx];
+      ASSERT_TRUE(px <= last_keep_index);
+      npart_found++;
+    }
+  }
+  // check number of remaining particles
+  int npart_total;
+  MPICHK(MPI_Allreduce(&npart_found, &npart_total, 1, MPI_INT, MPI_SUM,
+                       sycl_target->comm_pair.comm_parent));
+
+  ASSERT_EQ(npart_total, (last_keep_index + 1));
 
   mesh->free();
   A->free();
 }
-


### PR DESCRIPTION
## Description

Adds a better user facing interface for removing particles from a ParticleGroup. 
Includes a bugfix for cmake linking tests into one binary.

## Type of Change
Feature

## Testing
New test added for new feature. Existing tests still pass with hipsycl/Oneapi.


