### PR TITLE
backport to NESO-Particles of method to initialise particle distribut…

### DIFF
--- a/include/mesh_interface.hpp
+++ b/include/mesh_interface.hpp
@@ -104,13 +104,11 @@ public:
   /**
    *  Get a point in the domain that should be in, or at least close to, the
    *  sub-domain on this MPI process. Useful for parallel initialisation.
-   *  Returns false if this mesh implementation does not implement this
-   *  feature.
    *
    *  @param point Pointer to array of size equal to at least the number of mesh
    * dimensions.
    */
-  virtual inline bool get_point_in_subdomain(double *point) { return false; };
+  virtual inline void get_point_in_subdomain(double *point) = 0;
 };
 
 typedef std::shared_ptr<HMesh> HMeshSharedPtr;
@@ -382,13 +380,12 @@ public:
     return this->neighbour_ranks;
   }
 
-  inline bool get_point_in_subdomain(double *point) {
+  inline void get_point_in_subdomain(double *point) {
     for (int dimx = 0; dimx < ndim; dimx++) {
       const double start = this->cell_starts[dimx] * this->cell_width_fine;
       const double end = this->cell_ends[dimx] * this->cell_width_fine;
       point[dimx] = 0.5 * (start + end);
     }
-    return true;
   };
 };
 

--- a/include/mesh_interface.hpp
+++ b/include/mesh_interface.hpp
@@ -101,6 +101,16 @@ public:
    *  @returns std::vector of MPI ranks.
    */
   virtual inline std::vector<int> &get_local_communication_neighbours() = 0;
+  /**
+   *  Get a point in the domain that should be in, or at least close to, the
+   *  sub-domain on this MPI process. Useful for parallel initialisation.
+   *  Returns false if this mesh implementation does not implement this
+   *  feature.
+   *
+   *  @param point Pointer to array of size equal to at least the number of mesh
+   * dimensions.
+   */
+  virtual inline bool get_point_in_subdomain(double *point) { return false; };
 };
 
 typedef std::shared_ptr<HMesh> HMeshSharedPtr;
@@ -371,6 +381,15 @@ public:
   inline std::vector<int> &get_local_communication_neighbours() {
     return this->neighbour_ranks;
   }
+
+  inline bool get_point_in_subdomain(double *point) {
+    for (int dimx = 0; dimx < ndim; dimx++) {
+      const double start = this->cell_starts[dimx] * this->cell_width_fine;
+      const double end = this->cell_ends[dimx] * this->cell_width_fine;
+      point[dimx] = 0.5 * (start + end);
+    }
+    return true;
+  };
 };
 
 typedef std::shared_ptr<CartesianHMesh> CartesianHMeshSharedPtr;

--- a/include/mesh_interface_local_decomp.hpp
+++ b/include/mesh_interface_local_decomp.hpp
@@ -149,7 +149,7 @@ public:
    *
    * @returns MeshHierarchy placed over the mesh.
    */
-  virtual inline std::shared_ptr<MeshHierarchy> get_mesh_hierarchy() {
+  inline std::shared_ptr<MeshHierarchy> get_mesh_hierarchy() {
     return this->mesh_hierarchy;
   };
   /**
@@ -162,8 +162,20 @@ public:
    *
    *  @returns std::vector of MPI ranks.
    */
-  virtual inline std::vector<int> &get_local_communication_neighbours() {
+  inline std::vector<int> &get_local_communication_neighbours() {
     return this->neighbour_ranks;
+  };
+  /**
+   *  Get a point in the domain that should be in, or at least close to, the
+   *  sub-domain on this MPI process. Useful for parallel initialisation.
+   *
+   *  @param point Pointer to array of size equal to at least the number of mesh
+   * dimensions.
+   */
+  inline void get_point_in_subdomain(double *point) {
+    for (int dimx = 0; dimx < this->ndim; dimx++) {
+      point[dimx] = this->global_origin[dimx];
+    }
   };
 };
 

--- a/include/neso_particles.hpp
+++ b/include/neso_particles.hpp
@@ -16,6 +16,7 @@
 #include "mesh_hierarchy.hpp"
 #include "mesh_interface.hpp"
 #include "mesh_interface_local_decomp.hpp"
+#include "parallel_initialisation.hpp"
 #include "particle_dat.hpp"
 #include "particle_group.hpp"
 #include "particle_io.hpp"

--- a/include/parallel_initialisation.hpp
+++ b/include/parallel_initialisation.hpp
@@ -109,9 +109,16 @@ inline void parallel_advection_restore(ParticleGroupSharedPtr particle_group) {
           const INT layerx = NESO_PARTICLES_KERNEL_LAYER;
 
           for (int nx = 0; nx < space_ncomp; nx++) {
+            const REAL position_original = k_ORIG_POS[cellx][nx][layerx];
+            const REAL position_current = k_P[cellx][nx][layerx];
 
-            const bool valid = ABS(k_ORIG_POS[cellx][nx][layerx] -
-                                   k_P[cellx][nx][layerx]) < 1.0e-6;
+            const REAL error_abs = ABS(position_original - position_current);
+            const bool valid_abs = error_abs < 1.0e-6;
+            const REAL position_abs = ABS(position_original);
+            const REAL error_rel =
+                (position_abs == 0) ? 0.0 : error_abs / position_abs;
+            const bool valid_rel = error_rel < 1.0e-6;
+            const bool valid = valid_abs || valid_rel;
 
             NESO_KERNEL_ASSERT(valid, k_ep);
             k_P[cellx][nx][layerx] = k_ORIG_POS[cellx][nx][layerx];

--- a/include/parallel_initialisation.hpp
+++ b/include/parallel_initialisation.hpp
@@ -137,7 +137,7 @@ inline void parallel_advection_restore(ParticleGroupSharedPtr particle_group) {
 
 /**
  *  Function used by parallel_advection_initialisation to step particles along a
- * line to destination positions.
+ *  line to the original positions specified by the user.
  *
  *  @param particle_group ParticleGroup being initialised.
  *  @param num_steps Number of steps over which the stepping occurs.

--- a/include/parallel_initialisation.hpp
+++ b/include/parallel_initialisation.hpp
@@ -18,12 +18,7 @@ namespace {
  */
 inline void get_point_in_local_domain(ParticleGroupSharedPtr particle_group,
                                       double *point) {
-
-  auto mesh = particle_group->domain->mesh;
-  bool is_defined = mesh->get_point_in_subdomain(point);
-  NESOASSERT(is_defined,
-             "This mesh type does not define get_point_in_subdomain which is "
-             "required to use this parallel initialisation system.");
+  particle_group->domain->mesh->get_point_in_subdomain(point);
 }
 
 /**

--- a/include/parallel_initialisation.hpp
+++ b/include/parallel_initialisation.hpp
@@ -1,0 +1,214 @@
+#ifndef __NESO_PARTICLES_PARALLEL_INITIALISATION
+#define __NESO_PARTICLES_PARALLEL_INITIALISATION
+
+#include "particle_group.hpp"
+#include <memory>
+
+namespace NESO::Particles {
+
+namespace {
+
+/**
+ * Function used by parallel_advection_initialisation to step particles along a
+ * line to destination positions. Gets a safe temporary position in the local
+ * subdomain from which to start particle movement.
+ *
+ * @param particle_group ParticleGroup being initialised.
+ * @param point Output point in local subdomain.
+ */
+inline void get_point_in_local_domain(ParticleGroupSharedPtr particle_group,
+                                      double *point) {
+
+  auto mesh = particle_group->domain->mesh;
+  bool is_defined = mesh->get_point_in_subdomain(point);
+  NESOASSERT(is_defined,
+             "This mesh type does not define get_point_in_subdomain which is "
+             "required to use this parallel initialisation system.");
+}
+
+/**
+ *  Function used by parallel_advection_initialisation to step particles along a
+ * line to destination positions. Stores the original particle positions.
+ *
+ *  @param particle_group ParticleGroup being initialised.
+ */
+inline void parallel_advection_store(ParticleGroupSharedPtr particle_group) {
+
+  const int space_ncomp = particle_group->position_dat->ncomp;
+  auto domain = particle_group->domain;
+  auto sycl_target = particle_group->sycl_target;
+  particle_group->add_particle_dat(ParticleDat(
+      sycl_target, ParticleProp(Sym<REAL>("NESO_ORIG_POS"), space_ncomp),
+      domain->mesh->get_cell_count()));
+
+  double local_point[3];
+  get_point_in_local_domain(particle_group, local_point);
+
+  auto k_P = particle_group->position_dat->cell_dat.device_ptr();
+  auto k_ORIG_POS =
+      (*particle_group)[Sym<REAL>("NESO_ORIG_POS")]->cell_dat.device_ptr();
+  auto pl_iter_range =
+      particle_group->mpi_rank_dat->get_particle_loop_iter_range();
+  auto pl_stride =
+      particle_group->mpi_rank_dat->get_particle_loop_cell_stride();
+  auto pl_npart_cell =
+      particle_group->mpi_rank_dat->get_particle_loop_npart_cell();
+
+  sycl::buffer<double, 1> b_local_point(local_point, 3);
+
+  // store the target position on the particle and set the starting point.
+  sycl_target->queue
+      .submit([&](sycl::handler &cgh) {
+        auto a_local_point =
+            b_local_point.get_access<sycl::access::mode::read>(cgh);
+        cgh.parallel_for<>(sycl::range<1>(pl_iter_range), [=](sycl::id<1> idx) {
+          NESO_PARTICLES_KERNEL_START
+          const INT cellx = NESO_PARTICLES_KERNEL_CELL;
+          const INT layerx = NESO_PARTICLES_KERNEL_LAYER;
+          for (int nx = 0; nx < space_ncomp; nx++) {
+            k_ORIG_POS[cellx][nx][layerx] = k_P[cellx][nx][layerx];
+            k_P[cellx][nx][layerx] = a_local_point[nx];
+          }
+
+          NESO_PARTICLES_KERNEL_END
+        });
+      })
+      .wait_and_throw();
+}
+
+/**
+ *  Function used by parallel_advection_initialisation to step particles along a
+ * line to destination positions. Sets the particle positions to the original
+ * positions specified by the user.
+ *
+ *  @param particle_group ParticleGroup being initialised.
+ */
+inline void parallel_advection_restore(ParticleGroupSharedPtr particle_group) {
+
+  auto sycl_target = particle_group->sycl_target;
+  const int space_ncomp = particle_group->position_dat->ncomp;
+  auto k_P = particle_group->position_dat->cell_dat.device_ptr();
+  auto k_ORIG_POS =
+      (*particle_group)[Sym<REAL>("NESO_ORIG_POS")]->cell_dat.device_ptr();
+  auto pl_iter_range =
+      particle_group->mpi_rank_dat->get_particle_loop_iter_range();
+  auto pl_stride =
+      particle_group->mpi_rank_dat->get_particle_loop_cell_stride();
+  auto pl_npart_cell =
+      particle_group->mpi_rank_dat->get_particle_loop_npart_cell();
+
+  ErrorPropagate ep(sycl_target);
+  auto k_ep = ep.device_ptr();
+
+  // restore the target position
+  sycl_target->queue
+      .submit([&](sycl::handler &cgh) {
+        cgh.parallel_for<>(sycl::range<1>(pl_iter_range), [=](sycl::id<1> idx) {
+          NESO_PARTICLES_KERNEL_START
+          const INT cellx = NESO_PARTICLES_KERNEL_CELL;
+          const INT layerx = NESO_PARTICLES_KERNEL_LAYER;
+
+          for (int nx = 0; nx < space_ncomp; nx++) {
+
+            const bool valid = ABS(k_ORIG_POS[cellx][nx][layerx] -
+                                   k_P[cellx][nx][layerx]) < 1.0e-6;
+
+            NESO_KERNEL_ASSERT(valid, k_ep);
+            k_P[cellx][nx][layerx] = k_ORIG_POS[cellx][nx][layerx];
+          }
+
+          NESO_PARTICLES_KERNEL_END
+        });
+      })
+      .wait_and_throw();
+
+  ep.check_and_throw("Advected particle was very far from intended position.");
+
+  // remove the additional ParticleDat that was added
+  particle_group->remove_particle_dat(Sym<REAL>("NESO_ORIG_POS"));
+}
+
+/**
+ *  Function used by parallel_advection_initialisation to step particles along a
+ * line to destination positions.
+ *
+ *  @param particle_group ParticleGroup being initialised.
+ *  @param num_steps Number of steps over which the stepping occurs.
+ *  @param step The current step out of num_steps.
+ */
+inline void parallel_advection_step(ParticleGroupSharedPtr particle_group,
+                                    const int num_steps, const int step) {
+  auto sycl_target = particle_group->sycl_target;
+  const int space_ncomp = particle_group->position_dat->ncomp;
+  auto k_P = particle_group->position_dat->cell_dat.device_ptr();
+  auto k_ORIG_POS =
+      (*particle_group)[Sym<REAL>("NESO_ORIG_POS")]->cell_dat.device_ptr();
+  auto pl_iter_range =
+      particle_group->mpi_rank_dat->get_particle_loop_iter_range();
+  auto pl_stride =
+      particle_group->mpi_rank_dat->get_particle_loop_cell_stride();
+  auto pl_npart_cell =
+      particle_group->mpi_rank_dat->get_particle_loop_npart_cell();
+
+  const double steps_left = ((double)num_steps) - ((double)step);
+  const double inverse_steps_left = 1.0 / steps_left;
+
+  // move each particle along the line to the destination position.
+  sycl_target->queue
+      .submit([&](sycl::handler &cgh) {
+        cgh.parallel_for<>(sycl::range<1>(pl_iter_range), [=](sycl::id<1> idx) {
+          NESO_PARTICLES_KERNEL_START
+          const INT cellx = NESO_PARTICLES_KERNEL_CELL;
+          const INT layerx = NESO_PARTICLES_KERNEL_LAYER;
+
+          for (int nx = 0; nx < space_ncomp; nx++) {
+            const double offset =
+                k_ORIG_POS[cellx][nx][layerx] - k_P[cellx][nx][layerx];
+            k_P[cellx][nx][layerx] += inverse_steps_left * offset;
+          }
+
+          NESO_PARTICLES_KERNEL_END
+        });
+      })
+      .wait_and_throw();
+}
+
+} // namespace
+
+/**
+ *  Initialisation utility to aid parallel creation of particle distributions.
+ *  This function performs the all-to-all movement that occurs when a
+ *  ParticleGroup contains particles with positions (far) outside the owned
+ *  region of space. For example consider if each MPI rank creates N particles
+ *  uniformly distributed over the entire simulation domain then the call to
+ *  `hybrid_move` would have a cost equal to the number of MPI ranks squared.
+ *
+ *  This function gives each particle a temporary position in the owned
+ *  subdomain then moves the particles in a straight line to the original
+ *  positions in the positions ParticleDat. It is assumed that the simulation
+ *  domain is convex.
+ *
+ *  This function is used by adding particles with
+ *  `ParticleGroup.add_particles_local` on each rank then collectively calling
+ *  this function.
+ *
+ *  @param particle_group ParticleGroup to initialise by moving particles to the
+ * positions in the position ParticleDat.
+ *  @param num_steps optional number of steps to move particles over.
+ */
+inline void
+parallel_advection_initialisation(ParticleGroupSharedPtr particle_group,
+                                  const int num_steps = 20) {
+
+  parallel_advection_store(particle_group);
+  for (int stepx = 0; stepx < num_steps; stepx++) {
+    parallel_advection_step(particle_group, num_steps, stepx);
+    particle_group->hybrid_move();
+  }
+  parallel_advection_restore(particle_group);
+  particle_group->hybrid_move();
+}
+
+} // namespace NESO::Particles
+
+#endif

--- a/include/particle_group.hpp
+++ b/include/particle_group.hpp
@@ -335,10 +335,33 @@ public:
    *  data to print.
    */
   template <typename... T> inline void print(T... args);
+
+  /**
+   *  Remove a ParticleDat from the ParticleGroup
+   *
+   *  @param sym Sym object that refers to a ParticleDat
+   */
+  inline void remove_particle_dat(Sym<REAL> sym) {
+    NESOASSERT(this->particle_dats_real.count(sym) == 1,
+               "ParticleDat not found.");
+    this->particle_dats_real.erase(sym);
+  }
+  /**
+   *  Remove a ParticleDat from the ParticleGroup
+   *
+   *  @param sym Sym object that refers to a ParticleDat
+   */
+  inline void remove_particle_dat(Sym<INT> sym) {
+    NESOASSERT(this->particle_dats_int.count(sym) == 1,
+               "ParticleDat not found.");
+    this->particle_dats_int.erase(sym);
+  }
 };
 
 inline void
 ParticleGroup::add_particle_dat(ParticleDatSharedPtr<REAL> particle_dat) {
+  NESOASSERT(this->particle_dats_real.count(particle_dat->sym) == 0,
+             "ParticleDat Sym already exists in ParticleGroup.");
   this->particle_dats_real[particle_dat->sym] = particle_dat;
   // Does this dat hold particle positions?
   if (particle_dat->positions) {
@@ -354,6 +377,8 @@ ParticleGroup::add_particle_dat(ParticleDatSharedPtr<REAL> particle_dat) {
 }
 inline void
 ParticleGroup::add_particle_dat(ParticleDatSharedPtr<INT> particle_dat) {
+  NESOASSERT(this->particle_dats_int.count(particle_dat->sym) == 0,
+             "ParticleDat Sym already exists in ParticleGroup.");
   this->particle_dats_int[particle_dat->sym] = particle_dat;
   // Does this dat hold particle cell ids?
   if (particle_dat->positions) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,7 +45,7 @@ include(GoogleTest)
 foreach(TEST ${TEST_SRCS})
   get_filename_component(TEST_NAME ${TEST} NAME_WLE)
   message(STATUS "Found test - ${TEST_NAME}")
-  set(TEST_LIST ${TEST_LIST} ${TEST_NAME})
+  set(TEST_LIST ${TEST_LIST} ${TEST})
 
   set(TEST_SOURCES ${TEST_MAIN} ${TEST})
   add_executable(${TEST_NAME} ${TEST_SOURCES})

--- a/test/test_parallel_initialisation.cpp
+++ b/test/test_parallel_initialisation.cpp
@@ -1,0 +1,84 @@
+#include <CL/sycl.hpp>
+#include <gtest/gtest.h>
+#include <memory>
+#include <neso_particles.hpp>
+#include <random>
+
+using namespace NESO::Particles;
+
+TEST(ParallelInitialisation, initialisation) {
+
+  const int ndim = 2;
+  std::vector<int> dims(ndim);
+  dims[0] = 4;
+  dims[1] = 8;
+
+  const double cell_extent = 1.0;
+  const int subdivision_order = 2;
+  auto mesh = std::make_shared<CartesianHMesh>(MPI_COMM_WORLD, ndim, dims,
+                                               cell_extent, subdivision_order);
+
+  auto sycl_target =
+      std::make_shared<SYCLTarget>(GPU_SELECTOR, mesh->get_comm());
+
+  auto domain = std::make_shared<Domain>(mesh);
+  const int cell_count = domain->mesh->get_cell_count();
+
+  ParticleSpec particle_spec{ParticleProp(Sym<REAL>("P"), ndim, true),
+                             ParticleProp(Sym<INT>("CELL_ID"), 1, true),
+                             ParticleProp(Sym<INT>("ID"), 1),
+                             ParticleProp(Sym<REAL>("OP"), ndim)};
+
+  auto A = std::make_shared<ParticleGroup>(domain, particle_spec, sycl_target);
+  const int rank = sycl_target->comm_pair.rank_parent;
+
+  const int N = 2048;
+
+  // Add some particles and set flag such that roughly half should be removed
+  if (rank == 0) {
+    std::mt19937 rng_pos(52234234);
+    auto positions =
+        uniform_within_extents(N, ndim, mesh->global_extents, rng_pos);
+
+    ParticleSet initial_distribution(N, particle_spec);
+
+    for (int px = 0; px < N; px++) {
+      for (int dimx = 0; dimx < ndim; dimx++) {
+        initial_distribution[Sym<REAL>("P")][px][dimx] = positions[dimx][px];
+        initial_distribution[Sym<REAL>("OP")][px][dimx] = positions[dimx][px];
+      }
+      initial_distribution[Sym<INT>("CELL_ID")][px][0] = 0;
+      initial_distribution[Sym<INT>("ID")][px][0] = px;
+    }
+    A->add_particles_local(initial_distribution);
+  }
+
+  parallel_advection_initialisation(A);
+
+  int npart_found = 0;
+  for (int cellx = 0; cellx < cell_count; cellx++) {
+
+    auto P = (*A)[Sym<REAL>("P")]->cell_dat.get_cell(cellx);
+    auto OP = (*A)[Sym<REAL>("OP")]->cell_dat.get_cell(cellx);
+
+    for (int rowx = 0; rowx < P->nrow; rowx++) {
+      for (int colx = 0; colx < ndim; colx++) {
+        const INT p_test = (*P)[colx][rowx];
+        const INT p_correct = (*OP)[colx][rowx];
+        // these should be bitwise equal as they are copies.
+        ASSERT_TRUE(p_test == p_correct);
+      }
+      npart_found++;
+    }
+  }
+
+  // check none were lost
+  int npart_total;
+  MPICHK(MPI_Allreduce(&npart_found, &npart_total, 1, MPI_INT, MPI_SUM,
+                       sycl_target->comm_pair.comm_parent));
+
+  ASSERT_EQ(npart_total, N);
+
+  mesh->free();
+  A->free();
+}


### PR DESCRIPTION
…ions in parallel in convex domains

## Description

Solves the problem where MPI ranks initialise particles over the whole domain that then leads to particle movement that costs O(N^2) for N MPI ranks. Gives each particle a temporary position on the subdomain owned by the MPI rank then moves the particles to actual position by iteratively moving the particle along a line.

## Testing

New test added for user facing function. Tests pass with hipsycl+mpich and OneAPI/IntelMPI
