### PR TITLE
fix to prevent hdf5 errors when no particles are present

### DIFF
--- a/include/particle_io.hpp
+++ b/include/particle_io.hpp
@@ -4,6 +4,7 @@
 #include "particle_group.hpp"
 #include "particle_spec.hpp"
 #include "typedefs.hpp"
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <mpi.h>
@@ -247,63 +248,65 @@ public:
                      this->comm_pair.comm_parent));
     offset -= npart_local;
 
-    // Create a memspace and filespace for the columnwise writes.
-    hsize_t dims_memspace[1] = {static_cast<hsize_t>(npart_local)};
-    hid_t memspace = H5Screate_simple(1, dims_memspace, NULL);
+    if (npart_total > 0) {
 
-    hsize_t dims_filespace[1] = {static_cast<hsize_t>(npart_total)};
-    hid_t filespace = H5Screate_simple(1, dims_filespace, NULL);
+      // Create a memspace and filespace for the columnwise writes.
+      hsize_t dims_memspace[1] = {static_cast<hsize_t>(npart_local)};
+      hid_t memspace = H5Screate_simple(1, dims_memspace, NULL);
 
-    hsize_t slab_offsets[1] = {static_cast<hsize_t>(offset)};
-    hsize_t slab_counts[1] = {static_cast<hsize_t>(npart_local)};
+      hsize_t dims_filespace[1] = {static_cast<hsize_t>(npart_total)};
+      hid_t filespace = H5Screate_simple(1, dims_filespace, NULL);
 
-    // select the hyperslab for the columnwite writes.
-    H5CHK(H5Sselect_hyperslab(filespace, H5S_SELECT_SET, slab_offsets, NULL,
-                              slab_counts, NULL));
-    hid_t dxpl = H5Pcreate(H5P_DATASET_XFER);
-    H5CHK(H5Pset_dxpl_mpio(dxpl, H5FD_MPIO_COLLECTIVE));
+      hsize_t slab_offsets[1] = {static_cast<hsize_t>(offset)};
+      hsize_t slab_counts[1] = {static_cast<hsize_t>(npart_local)};
 
-    // create a host buffer in which to serialise the particle data before
-    // passing to HDF5
-    BufferHost<char> pack_buffer(this->particle_group->sycl_target,
-                                 npart_local * get_max_particle_size());
+      // select the hyperslab for the columnwite writes.
+      H5CHK(H5Sselect_hyperslab(filespace, H5S_SELECT_SET, slab_offsets, NULL,
+                                slab_counts, NULL));
+      hid_t dxpl = H5Pcreate(H5P_DATASET_XFER);
+      H5CHK(H5Pset_dxpl_mpio(dxpl, H5FD_MPIO_COLLECTIVE));
 
-    // Write the positions explicitly in a way Paraview interprets as a H5Part
-    // format.
-    write_dat_column_wise(npart_local, pack_buffer,
-                          this->particle_group->position_dat, dxpl, group_step,
-                          memspace, filespace, true);
+      // create a host buffer in which to serialise the particle data before
+      // passing to HDF5
+      BufferHost<char> pack_buffer(this->particle_group->sycl_target,
+                                   npart_local * get_max_particle_size());
 
-    // Write the particle data for each ParticleDat
-    if (multi_dim_mode) {
-      for (auto &sym : this->sym_store.syms_real) {
-        const auto dat = (*this->particle_group)[sym];
-        this->write_dat_2d(npart_total, npart_local, offset, pack_buffer, dat,
-                           group_step, dxpl);
+      // Write the positions explicitly in a way Paraview interprets as a H5Part
+      // format.
+      write_dat_column_wise(npart_local, pack_buffer,
+                            this->particle_group->position_dat, dxpl,
+                            group_step, memspace, filespace, true);
+
+      // Write the particle data for each ParticleDat
+      if (multi_dim_mode) {
+        for (auto &sym : this->sym_store.syms_real) {
+          const auto dat = (*this->particle_group)[sym];
+          this->write_dat_2d(npart_total, npart_local, offset, pack_buffer, dat,
+                             group_step, dxpl);
+        }
+        for (auto &sym : this->sym_store.syms_int) {
+          const auto dat = (*this->particle_group)[sym];
+          this->write_dat_2d(npart_total, npart_local, offset, pack_buffer, dat,
+                             group_step, dxpl);
+        }
+      } else {
+
+        for (auto &sym : this->sym_store.syms_real) {
+          const auto dat = (*this->particle_group)[sym];
+          write_dat_column_wise(npart_local, pack_buffer, dat, dxpl, group_step,
+                                memspace, filespace, false);
+        }
+        for (auto &sym : this->sym_store.syms_int) {
+          const auto dat = (*this->particle_group)[sym];
+          write_dat_column_wise(npart_local, pack_buffer, dat, dxpl, group_step,
+                                memspace, filespace, false);
+        }
       }
-      for (auto &sym : this->sym_store.syms_int) {
-        const auto dat = (*this->particle_group)[sym];
-        this->write_dat_2d(npart_total, npart_local, offset, pack_buffer, dat,
-                           group_step, dxpl);
-      }
-    } else {
 
-      for (auto &sym : this->sym_store.syms_real) {
-        const auto dat = (*this->particle_group)[sym];
-        write_dat_column_wise(npart_local, pack_buffer, dat, dxpl, group_step,
-                              memspace, filespace, false);
-      }
-      for (auto &sym : this->sym_store.syms_int) {
-        const auto dat = (*this->particle_group)[sym];
-        write_dat_column_wise(npart_local, pack_buffer, dat, dxpl, group_step,
-                              memspace, filespace, false);
-      }
+      H5CHK(H5Pclose(dxpl));
+      H5CHK(H5Sclose(filespace));
+      H5CHK(H5Sclose(memspace));
     }
-
-    H5CHK(H5Pclose(dxpl));
-    H5CHK(H5Sclose(filespace));
-    H5CHK(H5Sclose(memspace));
-
     H5CHK(H5Gclose(group_step));
     this->step++;
   };

--- a/test/test_particle_h5part.cpp
+++ b/test/test_particle_h5part.cpp
@@ -45,6 +45,12 @@ TEST(ParticleIO, H5Part) {
                                   ParticleProp(Sym<REAL>("FOO"), 3),
                                   domain->mesh->get_cell_count()));
 
+  H5Part h5parte("test_empty_dump.h5part", A, Sym<REAL>("P"), Sym<REAL>("V"),
+                 Sym<INT>("ID"), Sym<INT>("ID2"), Sym<INT>("NESO_MPI_RANK"));
+
+  h5parte.write();
+  h5parte.close();
+
   std::mt19937 rng_pos(52234234);
   std::mt19937 rng_vel(52234231);
   std::mt19937 rng_rank(18241);
@@ -88,7 +94,6 @@ TEST(ParticleIO, H5Part) {
 
   H5Part h5part("test_dump.h5part", A, Sym<REAL>("P"), Sym<REAL>("V"),
                 Sym<INT>("ID"), Sym<INT>("ID2"), Sym<INT>("NESO_MPI_RANK"));
-
   h5part.write();
   h5part.close();
 


### PR DESCRIPTION
Bug fix for when a ParticleGroup contains zero particles.

Added new test for zero particle case.