### PR TITLE
Feature/particle group get dat

### DIFF
--- a/include/particle_group.hpp
+++ b/include/particle_group.hpp
@@ -202,6 +202,17 @@ public:
   inline int get_npart_local() { return this->position_dat->get_npart_local(); }
 
   /**
+   * Template for get_dat method called like:
+   * ParticleGroup::get_dat(Sym<REAL>("POS")) for a real valued ParticleDat.
+   *
+   * @param name Name of ParticleDat.
+   * @returns ParticleDatSharedPtr<T> particle dat.
+   */
+  template <typename T> inline ParticleDatSharedPtr<T> get_dat(Sym<T> sym) {
+    return (*this)[sym];
+  }
+
+  /**
    *  Enables access to the ParticleDat instances using the subscript operators.
    *
    *  @param sym Sym<REAL> of ParticleDat to access.

--- a/test/test_particle_group.cpp
+++ b/test/test_particle_group.cpp
@@ -385,3 +385,33 @@ TEST(ParticleGroup, add_particle_dat) {
 
   mesh->free();
 }
+
+TEST(ParticleGroup, get_dat) {
+
+  const int ndim = 2;
+  std::vector<int> dims(ndim);
+  dims[0] = 4;
+  dims[1] = 8;
+
+  const double cell_extent = 1.0;
+  const int subdivision_order = 2;
+  auto mesh = std::make_shared<CartesianHMesh>(MPI_COMM_WORLD, ndim, dims,
+                                               cell_extent, subdivision_order);
+
+  auto sycl_target =
+      std::make_shared<SYCLTarget>(GPU_SELECTOR, mesh->get_comm());
+
+  auto domain = std::make_shared<Domain>(mesh);
+
+  ParticleSpec particle_spec{ParticleProp(Sym<REAL>("P"), ndim, true),
+                             ParticleProp(Sym<REAL>("V"), 3),
+                             ParticleProp(Sym<INT>("CELL_ID"), 1, true),
+                             ParticleProp(Sym<INT>("ID"), 1)};
+
+  auto A = std::make_shared<ParticleGroup>(domain, particle_spec, sycl_target);
+
+  ASSERT_EQ((*A)[Sym<REAL>("P")], A->get_dat(Sym<REAL>("P")));
+
+  ASSERT_EQ((*A)[Sym<INT>("ID")], A->get_dat(Sym<INT>("ID")));
+  mesh->free();
+}

--- a/test/test_particle_group_hybrid_move.cpp
+++ b/test/test_particle_group_hybrid_move.cpp
@@ -7,12 +7,15 @@
 
 using namespace NESO::Particles;
 
-TEST(ParticleGroup, hybrid_move_multiple) {
+class ParticleGroupHybridMove : public testing::TestWithParam<int> {};
 
-  const int ndim = 2;
-  std::vector<int> dims(ndim);
-  dims[0] = 8;
-  dims[1] = 4;
+TEST_P(ParticleGroupHybridMove, multiple) {
+
+  const int ndim = GetParam();
+  std::vector<int> dims(3);
+  dims[0] = (ndim == 2) ? 8 : 5;
+  dims[1] = (ndim == 2) ? 5 : 4;
+  dims[2] = 3;
 
   const double cell_extent = 1.0;
   const int subdivision_order = 1;
@@ -204,3 +207,6 @@ TEST(ParticleGroup, hybrid_move_multiple) {
   }
   mesh->free();
 }
+
+INSTANTIATE_TEST_SUITE_P(MultipleDim, ParticleGroupHybridMove,
+                         testing::Values(2, 3));


### PR DESCRIPTION
Added cleaner interface to retrieve particle dats from particle groups when the group is a shared pointer.