### PR TITLE
use a font that is easier for visual processing

### DIFF
--- a/docs/sphinx/source/_static/custom.css
+++ b/docs/sphinx/source/_static/custom.css
@@ -1,0 +1,16 @@
+/* Import from Google Fonts, a CDN, or files in your _static folder.
+   This Google Fonts import provides its own `@font-face` CSS;
+   if providing your own font files, you'll also need to
+   provide your own `@font-face` code. */
+@import url("https://fonts.googleapis.com/css?family=Atkinson+Hyperlegible");
+
+/* Main font used throughout the docs. */
+body {
+  font-family: "Atkinson Hyperlegible", sans-serif;
+}
+
+/* Code snippets. */
+pre, code, kbd, samp {
+  font-family: "Courier New", monospace;
+}
+

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -25,6 +25,7 @@ exclude_patterns = []
 
 html_theme = "pydata_sphinx_theme"
 html_static_path = ['_static']
+html_css_files = ["custom.css"]
 
 html_sidebars = {
     "**": ["globaltoc.html"]


### PR DESCRIPTION
Uses https://brailleinstitute.org/freefont, which sphinx downloads using googleapis as it needs it.