### PR TITLE
bug fix to exclude undefined values in mesh hierarchy plotting

### DIFF
--- a/include/utility_mesh_hierarchy_plotting.hpp
+++ b/include/utility_mesh_hierarchy_plotting.hpp
@@ -137,7 +137,13 @@ public:
     vtk_file << "POINTS " << this->index_to_verts.size() << " float\n";
 
     const double cell_width = this->mesh_hierarchy->cell_width_fine;
-    auto origin = this->mesh_hierarchy->origin;
+
+    auto origin_mh = this->mesh_hierarchy->origin;
+    double origin[3] = {0.0, 0.0, 0.0};
+    for (int dimx = 0; dimx < ndim; dimx++) {
+      origin[dimx] = origin_mh[dimx];
+    }
+
     for (INT vx = 0; vx < this->next_vert_index; vx++) {
       auto vertex = this->index_to_verts[vx];
       const double x = ((double)std::get<0>(vertex)) * cell_width + origin[0];


### PR DESCRIPTION
Bug fix to avoid undefined values in vtk output for mesh hierarchy.