### PR TITLE
Methods to test if a ParticleDat exists in a ParticleGroup

### DIFF
--- a/include/particle_group.hpp
+++ b/include/particle_group.hpp
@@ -202,17 +202,46 @@ public:
   inline int get_npart_local() { return this->position_dat->get_npart_local(); }
 
   /**
+   *  Determine if the ParticleGroup contains a ParticleDat of a given name.
+   *
+   *  @param sym Symbol of ParticleDat.
+   *  @returns True if ParticleDat exists on this ParticleGroup.
+   */
+  inline bool contains_dat(Sym<REAL> sym) {
+    return (bool)this->particle_dats_real.count(sym);
+  }
+
+  /**
+   *  Determine if the ParticleGroup contains a ParticleDat of a given name.
+   *
+   *  @param sym Symbol of ParticleDat.
+   *  @returns True if ParticleDat exists on this ParticleGroup.
+   */
+  inline bool contains_dat(Sym<INT> sym) {
+    return (bool)this->particle_dats_int.count(sym);
+  }
+
+  /**
    * Template for get_dat method called like:
    * ParticleGroup::get_dat(Sym<REAL>("POS")) for a real valued ParticleDat.
    *
    * @param name Name of ParticleDat.
+   * @param check_exists Check if the dat exists, default true.
    * @returns ParticleDatSharedPtr<T> particle dat.
    */
-  template <typename T> inline ParticleDatSharedPtr<T> get_dat(Sym<T> sym) {
+  template <typename T>
+  inline ParticleDatSharedPtr<T> get_dat(Sym<T> sym,
+                                         const bool check_exists = true) {
+    if (check_exists) {
+      const bool dat_exists = this->contains_dat(sym);
+      NESOASSERT(dat_exists,
+                 "This ParticleGroup does not contain the requested dat.");
+    }
     return (*this)[sym];
   }
 
   /**
+   *  Users are recomended to use "get_dat" instead.
    *  Enables access to the ParticleDat instances using the subscript operators.
    *
    *  @param sym Sym<REAL> of ParticleDat to access.
@@ -221,6 +250,7 @@ public:
     return this->particle_dats_real.at(sym);
   };
   /**
+   *  Users are recomended to use "get_dat" instead.
    *  Enables access to the ParticleDat instances using the subscript operators.
    *
    *  @param sym Sym<INT> of ParticleDat to access.

--- a/test/test_particle_group.cpp
+++ b/test/test_particle_group.cpp
@@ -413,5 +413,11 @@ TEST(ParticleGroup, get_dat) {
   ASSERT_EQ((*A)[Sym<REAL>("P")], A->get_dat(Sym<REAL>("P")));
 
   ASSERT_EQ((*A)[Sym<INT>("ID")], A->get_dat(Sym<INT>("ID")));
+
+  ASSERT_EQ(A->contains_dat(Sym<REAL>("FOO")), false);
+  ASSERT_EQ(A->contains_dat(Sym<INT>("FOO")), false);
+  ASSERT_EQ(A->contains_dat(Sym<REAL>("P")), true);
+  ASSERT_EQ(A->contains_dat(Sym<INT>("ID")), true);
+
   mesh->free();
 }

--- a/test/test_particle_h5part.cpp
+++ b/test/test_particle_h5part.cpp
@@ -94,6 +94,7 @@ TEST(ParticleIO, H5Part) {
 
   H5Part h5part("test_dump.h5part", A, Sym<REAL>("P"), Sym<REAL>("V"),
                 Sym<INT>("ID"), Sym<INT>("ID2"), Sym<INT>("NESO_MPI_RANK"));
+
   h5part.write();
   h5part.close();
 


### PR DESCRIPTION
Added user callable test to check a ParticleGroup contains a ParticleDat Sym. Added check to H5Part class on call to write.

# Tests
Added test to the ParticleGroup tests for the new method.