### PR TITLE
Removed printing to stdout every time a SYCLTarget is constructed

### DIFF
--- a/include/compute_target.hpp
+++ b/include/compute_target.hpp
@@ -131,12 +131,6 @@ public:
           "SYCL", this->device.get_info<sycl::info::device::name>(), 0);
     }
 
-    if (this->comm_pair.rank_parent == 0) {
-      std::cout << "Using " << this->device.get_info<sycl::info::device::name>()
-                << std::endl;
-      std::cout << "Kernel type: " << NESO_PARTICLES_DEVICE_LABEL << std::endl;
-    }
-
     this->queue = sycl::queue(this->device);
     this->comm = comm;
 
@@ -161,6 +155,17 @@ public:
       nprint("ALL FREED");
     }
 #endif
+  }
+
+  /**
+   * Print information to stdout about the current SYCL device (on MPI rank 0).
+   */
+  inline void print_device_info() {
+    if (this->comm_pair.rank_parent == 0) {
+      std::cout << "Using " << this->device.get_info<sycl::info::device::name>()
+                << std::endl;
+      std::cout << "Kernel type: " << NESO_PARTICLES_DEVICE_LABEL << std::endl;
+    }
   }
 
   /**

--- a/test/test_sycl_target.cpp
+++ b/test/test_sycl_target.cpp
@@ -1,0 +1,13 @@
+#include <CL/sycl.hpp>
+#include <gtest/gtest.h>
+#include <memory>
+#include <neso_particles.hpp>
+
+using namespace NESO::Particles;
+
+TEST(SYCLTarget, print_device_info) {
+
+  auto sycl_target = std::make_shared<SYCLTarget>(0, MPI_COMM_WORLD);
+
+  sycl_target->print_device_info();
+}


### PR DESCRIPTION
Starting to see much text on stdout from everytime  a SYCLTarget is constructed. Removed the text from the constructor and added a method to print the information if required.