### PR TITLE
bugfix to pass RNGs by reference not value

### DIFF
--- a/include/utility.hpp
+++ b/include/utility.hpp
@@ -20,12 +20,13 @@ namespace NESO::Particles {
  *  @param N Number of points to generate.
  *  @param ndim Number of dimensions.
  *  @param extents Extent of each of the dimensions.
- *  @param rng Optional RNG to use.
+ *  @param rng RNG to use.
  *  @returns (N)x(ndim) set of positions stored for each column.
  */
+template <typename RNG>
 inline std::vector<std::vector<double>>
 uniform_within_extents(const int N, const int ndim, const double *extents,
-                       std::mt19937 rng = std::mt19937()) {
+                       RNG &rng) {
 
   std::uniform_real_distribution<double> uniform_rng(0.0, 1.0);
   std::vector<std::vector<double>> positions(ndim);
@@ -47,12 +48,13 @@ uniform_within_extents(const int N, const int ndim, const double *extents,
  *  @param ndim Number of dimensions.
  *  @param mu Mean to use for Gaussian distribution.
  *  @param sigma Sigma to use for Gaussian distribution.
- *  @param rng Optional RNG to use.
+ *  @param rng RNG to use.
  *  @returns (N)x(ndim) set of samples stored per column.
  */
+template <typename RNG>
 inline std::vector<std::vector<double>>
 normal_distribution(const int N, const int ndim, const double mu,
-                    const double sigma, std::mt19937 rng = std::mt19937()) {
+                    const double sigma, RNG &rng) {
 
   std::normal_distribution<> d{mu, sigma};
   std::vector<std::vector<double>> array(ndim);
@@ -64,6 +66,36 @@ normal_distribution(const int N, const int ndim, const double mu,
   }
 
   return array;
+}
+
+/**
+ *  Create a uniform distribution of particle positions within a set of extents.
+ *
+ *  @param N Number of points to generate.
+ *  @param ndim Number of dimensions.
+ *  @param extents Extent of each of the dimensions.
+ *  @returns (N)x(ndim) set of positions stored for each column.
+ */
+inline std::vector<std::vector<double>>
+uniform_within_extents(const int N, const int ndim, const double *extents) {
+  std::mt19937 rng = std::mt19937(std::random_device{}());
+  return uniform_within_extents(N, ndim, extents, rng);
+}
+
+/**
+ *  Create (N)x(ndim) set of samples from a Gaussian distribution.
+ *
+ *  @param N Number of points to generate.
+ *  @param ndim Number of dimensions.
+ *  @param mu Mean to use for Gaussian distribution.
+ *  @param sigma Sigma to use for Gaussian distribution.
+ *  @returns (N)x(ndim) set of samples stored per column.
+ */
+inline std::vector<std::vector<double>>
+normal_distribution(const int N, const int ndim, const double mu,
+                    const double sigma) {
+  std::mt19937 rng = std::mt19937(std::random_device{}());
+  return normal_distribution(N, ndim, mu, sigma, rng);
 }
 
 } // namespace NESO::Particles

--- a/test/test_utility.cpp
+++ b/test/test_utility.cpp
@@ -1,0 +1,70 @@
+#include <CL/sycl.hpp>
+#include <gtest/gtest.h>
+#include <neso_particles.hpp>
+using namespace NESO::Particles;
+
+TEST(Utility, UniformWithinExtents) {
+
+  {
+    std::mt19937 rng = std::mt19937(std::random_device{}());
+    const double extents[1] = {1.0};
+    auto u0 = uniform_within_extents(1, 1, extents, rng);
+    auto u1 = uniform_within_extents(1, 1, extents, rng);
+    ASSERT_TRUE(u0[0][0] != u1[0][0]);
+  }
+
+  {
+    const double extents[1] = {1.0};
+    auto u0 = uniform_within_extents(1, 1, extents);
+    auto u1 = uniform_within_extents(1, 1, extents);
+    ASSERT_TRUE(u0[0][0] != u1[0][0]);
+  }
+
+  {
+    std::mt19937 rng0 = std::mt19937(123);
+    const double extents[1] = {1.0};
+    auto u0 = uniform_within_extents(1, 1, extents, rng0);
+
+    std::mt19937 rng1 = std::mt19937(123);
+    auto u1 = uniform_within_extents(1, 1, extents, rng1);
+    ASSERT_TRUE(u0[0][0] == u1[0][0]);
+  }
+
+  {
+    std::mt19937 rng0 = std::mt19937(123);
+    const double extents[3] = {1.0, 2.0, 3.0};
+    auto u = uniform_within_extents(32, 3, extents, rng0);
+    for (int ix = 0; ix < 32; ix++) {
+      for (int dx = 0; dx < 3; dx++) {
+        ASSERT_TRUE(u[dx][ix] >= 0.0);
+        ASSERT_TRUE(u[dx][ix] <= extents[dx]);
+      }
+    }
+  }
+}
+
+TEST(Utility, NormalDistribution) {
+
+  {
+    std::mt19937 rng = std::mt19937(std::random_device{}());
+    auto u0 = NESO::Particles::normal_distribution(1, 1, 1.0, 1.0, rng);
+    auto u1 = NESO::Particles::normal_distribution(1, 1, 1.0, 1.0, rng);
+    ASSERT_TRUE(u0[0][0] != u1[0][0]);
+  }
+
+  {
+    auto u0 = NESO::Particles::normal_distribution(1, 1, 1.0, 1.0);
+    auto u1 = NESO::Particles::normal_distribution(1, 1, 1.0, 1.0);
+    ASSERT_TRUE(u0[0][0] != u1[0][0]);
+  }
+
+  {
+    std::mt19937 rng0 = std::mt19937(123);
+    const double extents[1] = {1.0};
+    auto u0 = NESO::Particles::normal_distribution(1, 1, 2.0, 3.0, rng0);
+
+    std::mt19937 rng1 = std::mt19937(123);
+    auto u1 = NESO::Particles::normal_distribution(1, 1, 2.0, 3.0, rng1);
+    ASSERT_TRUE(u0[0][0] == u1[0][0]);
+  }
+}

--- a/test/test_utility.cpp
+++ b/test/test_utility.cpp
@@ -17,7 +17,7 @@ TEST(Utility, UniformWithinExtents) {
     const double extents[1] = {1.0};
     auto u0 = uniform_within_extents(1, 1, extents);
     auto u1 = uniform_within_extents(1, 1, extents);
-    ASSERT_TRUE(u0[0][0] != u1[0][0]);
+    EXPECT_TRUE(u0[0][0] != u1[0][0]);
   }
 
   {
@@ -55,7 +55,7 @@ TEST(Utility, NormalDistribution) {
   {
     auto u0 = NESO::Particles::normal_distribution(1, 1, 1.0, 1.0);
     auto u1 = NESO::Particles::normal_distribution(1, 1, 1.0, 1.0);
-    ASSERT_TRUE(u0[0][0] != u1[0][0]);
+    EXPECT_TRUE(u0[0][0] != u1[0][0]);
   }
 
   {


### PR DESCRIPTION
Passes RNGs by reference instead of value to ensure the passed RNG is modified.