### PR TITLE
added missing call to MPI_Abort in NESOASSERT

### DIFF
--- a/cmake/neso-particles-config.cmake
+++ b/cmake/neso-particles-config.cmake
@@ -21,7 +21,7 @@ endif()
 set(HDF5_PREFER_PARALLEL TRUE)
 find_package(HDF5 QUIET)
 
-if(HDF5_FOUND)
+if(HDF5_FOUND AND HDF5_IS_PARALLEL)
     message(STATUS "HDF5 found")
     add_definitions(-DNESO_PARTICLES_HDF5)
     add_definitions(${HDF5_DEFINITIONS})
@@ -30,6 +30,5 @@ if(HDF5_FOUND)
 else()
     message(STATUS "HDF5 NOT found")
 endif()
-
-
+message(STATUS "HDF5_IS_PARALLEL " ${HDF5_IS_PARALLEL})
 

--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -471,7 +471,7 @@ LOOKUP_CACHE_SIZE      = 0
 # DOT_NUM_THREADS setting.
 # Minimum value: 0, maximum value: 32, default value: 1.
 
-NUM_PROC_THREADS       = 1
+NUM_PROC_THREADS       = 0
 
 #---------------------------------------------------------------------------
 # Build related configuration options
@@ -485,7 +485,7 @@ NUM_PROC_THREADS       = 1
 # normally produced when WARNINGS is set to YES.
 # The default value is: NO.
 
-EXTRACT_ALL            = NO
+EXTRACT_ALL            = YES
 
 # If the EXTRACT_PRIVATE tag is set to YES, all private members of a class will
 # be included in the documentation.

--- a/include/typedefs.hpp
+++ b/include/typedefs.hpp
@@ -22,10 +22,26 @@ static inline int reduce_mul(const int nel, std::vector<int> &values) {
 }
 
 #define NESOASSERT(expr, msg)                                                  \
-  neso_particle_assert(#expr, expr, __FILE__, __LINE__, msg)
+  neso_particles_assert(#expr, expr, __FILE__, __LINE__, msg)
 
-inline void neso_particle_assert(const char *expr_str, bool expr,
-                                 const char *file, int line, const char *msg) {
+/**
+ * This is a helper function to assert conditions are satisfied and terminate
+ * execution if not. An error is output on stderr and MPI_Abort is called if
+ * MPI is initialised. Users should call the corresponding helper macro
+ * NESOASSERT like
+ *
+ *   NESOASSERT(conditional, message);
+ *
+ * To check conditionals within their code.
+ *
+ * @param expr_str A string identifying the conditional to check.
+ * @param expr Bool resulting from the evaluation of the expression.
+ * @param file Filename containing the call to neso_particles_assert.
+ * @param line Line number for the call to neso_particles assert.
+ * @param msg Message to print to stderr on evaluation of conditional to false.
+ */
+inline void neso_particles_assert(const char *expr_str, bool expr,
+                                  const char *file, int line, const char *msg) {
   if (!expr) {
     std::cerr << "NESO Particles Assertion error:\t" << msg << "\n"
               << "Expected value:\t" << expr_str << "\n"

--- a/include/typedefs.hpp
+++ b/include/typedefs.hpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
+#include <mpi.h>
 #include <numeric>
 #include <vector>
 
@@ -29,7 +30,13 @@ inline void neso_particle_assert(const char *expr_str, bool expr,
     std::cerr << "NESO Particles Assertion error:\t" << msg << "\n"
               << "Expected value:\t" << expr_str << "\n"
               << "Source location:\t\t" << file << ", line " << line << "\n";
-    abort();
+    int flag = 0;
+    MPI_Initialized(&flag);
+    if (flag) {
+      MPI_Abort(MPI_COMM_WORLD, -1);
+    } else {
+      std::abort();
+    }
   }
 }
 

--- a/include/typedefs.hpp
+++ b/include/typedefs.hpp
@@ -22,7 +22,7 @@ static inline int reduce_mul(const int nel, std::vector<int> &values) {
 }
 
 #define NESOASSERT(expr, msg)                                                  \
-  neso_particles_assert(#expr, expr, __FILE__, __LINE__, msg)
+  NESO::Particles::neso_particles_assert(#expr, expr, __FILE__, __LINE__, msg)
 
 /**
  * This is a helper function to assert conditions are satisfied and terminate

--- a/include/typedefs.hpp
+++ b/include/typedefs.hpp
@@ -21,6 +21,15 @@ static inline int reduce_mul(const int nel, std::vector<int> &values) {
   return v;
 }
 
+/**
+ * \def NESOASSERT(expr, msg)
+ * This is a helper macro to call the function neso_particles_assert. Users
+ * should call this helper macro NESOASSERT like
+ *
+ *   NESOASSERT(conditional, message);
+ *
+ * To check conditionals within their code.
+ */
 #define NESOASSERT(expr, msg)                                                  \
   NESO::Particles::neso_particles_assert(#expr, expr, __FILE__, __LINE__, msg)
 


### PR DESCRIPTION
Adds the missing implementation in NESOASSERT to attempt to cleanly terminate execution on call to NESOASSERT.