### PR TITLE
Allow project to build when using recent releases of HDF5

### DIFF
--- a/cmake/neso-particles-config.cmake
+++ b/cmake/neso-particles-config.cmake
@@ -19,6 +19,7 @@ else()
 endif()
 
 set(HDF5_PREFER_PARALLEL TRUE)
+enable_language(C)
 find_package(HDF5 QUIET)
 
 if(HDF5_FOUND)


### PR DESCRIPTION
I did some investigation into #37 and found that the reason we are getting CMake errors when trying to build against recent versions of HDF5 is because they make MPI_C a public dependency. Even though we import MPI, CMake only imports the MPI libraries corresponding to the language(s) of the  the project we are working on which, in our case, is C++. I have raised a bug report with HDF5 (HDFGroup/hdf5#3844). In the meantime, this PR will fix the issue for us.