### PR TITLE
corrected MPI thread initialisation

### DIFF
--- a/include/typedefs.hpp
+++ b/include/typedefs.hpp
@@ -165,6 +165,43 @@ template <typename... T> inline void nprint(T... args) {
 //#define DEBUG_OOB_CHECK
 #define DEBUG_OOB_WIDTH 1000
 
+/**
+ * Get the MPI thread level required by NESO-Particles. MPI should be
+ * initialised by calling MPI_Init_thread with a required thread level greater
+ * than or equal to the value returned by this function.
+ *
+ * @returns MPI thread level.
+ */
+inline int get_required_mpi_thread_level() { return MPI_THREAD_FUNNELED; }
+
+/**
+ * Test that a provided MPI thread level is sufficient for NESO-Particles.
+ *
+ * @param level Provided thread level.
+ */
+inline void test_provided_thread_level(const int level) {
+  NESOASSERT(level >= get_required_mpi_thread_level(),
+             "Provided MPI thread level is insufficient for NESO-Particles.");
+}
+
+/**
+ * Helper function to initialise MPI and check that the provided thread level
+ * is sufficient. Calling this function is equivalent to calling
+ * MPI_Init_thread with the required thread level from
+ * get_required_mpi_thread_level and checking the provided thread level is
+ * equal to or greater than this required level.
+ *
+ * @param argc Pointer to the number of arguments.
+ * @param argv Argument vector.
+ */
+inline void initialise_mpi(int *argc, char ***argv) {
+  int provided_thread_level;
+  NESOASSERT(MPI_Init_thread(argc, argv, get_required_mpi_thread_level(),
+                             &provided_thread_level) == MPI_SUCCESS,
+             "ERROR: MPI_Init_thread != MPI_SUCCESS");
+  test_provided_thread_level(provided_thread_level);
+}
+
 } // namespace NESO::Particles
 
 #endif

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 #include <iostream>
 #include <mpi.h>
+#include <typedefs.hpp>
 
 /*
  *  If an exception is thrown try and abort MPI cleanly to prevent a deadlock.
@@ -12,10 +13,7 @@ void TerminateHandler() {
 
 int main(int argc, char **argv) {
 
-  if (MPI_Init(&argc, &argv) != MPI_SUCCESS) {
-    std::cout << "ERROR: MPI_Init != MPI_SUCCESS" << std::endl;
-    return -1;
-  }
+  NESO::Particles::initialise_mpi(&argc, &argv);
 
 #if GTEST_HAS_EXCEPTIONS
   std::set_terminate(&TerminateHandler);


### PR DESCRIPTION
Corrects the MPI initialisation to be a correct and portable MPI program. Assumes that at least one thread will be made by as sycl implementation and chooses a safe default for this scenario.