### PR TITLE
move placement of find mpi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,6 @@ if(ENABLE_NESO_PARTICLES_TESTS)
     message(STATUS "Set CMAKE_BUILD_TYPE=RelWithDebInfo")
   endif()
 
-  # find MPI
-  find_package(MPI REQUIRED)
-
   # find NESO-Particles config
   list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}")
   find_package(NESO-PARTICLES REQUIRED)

--- a/cmake/neso-particles-config.cmake
+++ b/cmake/neso-particles-config.cmake
@@ -18,10 +18,15 @@ else()
   message(STATUS "Using NESO_PARTICLES_DEVICE_TYPE_CPU")
 endif()
 
-set(HDF5_PREFER_PARALLEL TRUE)
+# required for some versions of hdf5
 enable_language(C)
-find_package(HDF5 QUIET)
 
+# find/re-find MPI with MPI_C
+find_package(MPI REQUIRED)
+
+# now look for HDF5
+set(HDF5_PREFER_PARALLEL TRUE)
+find_package(HDF5 QUIET)
 if(HDF5_FOUND AND HDF5_IS_PARALLEL)
     message(STATUS "HDF5 found")
     add_definitions(-DNESO_PARTICLES_HDF5)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,8 +25,6 @@ endif()
 set(EXECUTABLE testNESOParticles)
 set(TEST_MAIN ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
 
-find_package(MPI REQUIRED)
-
 # List test source files
 file(GLOB TEST_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/test_*.cpp
      ${CMAKE_CURRENT_SOURCE_DIR}/*_test.cpp)


### PR DESCRIPTION
Downstream projects depending on HDF5 transitively through the NP cmake need to have C enabled as a language, then find MPI_C and HDF5. 
Should tackle: https://github.com/ExCALIBUR-NEPTUNE/NESO/issues/218