### PR TITLE
Added cmake functionality to determine and define C++ restrict keyword

### DIFF
--- a/cmake/neso-particles-config.cmake
+++ b/cmake/neso-particles-config.cmake
@@ -2,6 +2,8 @@
 get_filename_component(NESO_PARTICLES_ROOT "${CMAKE_CURRENT_LIST_DIR}/../"
                        ABSOLUTE)
 
+include(${CMAKE_CURRENT_LIST_DIR}/restrict-keyword.cmake)
+
 # set the variable for projects to use to find header files
 set(NESO_PARTICLES_INCLUDE_PATH ${NESO_PARTICLES_ROOT}/include)
 

--- a/cmake/restrict-keyword.cmake
+++ b/cmake/restrict-keyword.cmake
@@ -1,0 +1,40 @@
+# try to find an acceptable CXX restrict keyword if not user provided
+INCLUDE(CheckCXXSourceCompiles)
+
+if(NOT DEFINED RESTRICT)
+    message(STATUS "Detecting restrict keyword")
+    check_cxx_source_compiles(
+        "
+        int f(void *restrict x);
+        int main(void) {return 0;}
+        "
+        HAVERESTRICT
+    )
+    check_cxx_source_compiles(
+        "
+        int f(void * __restrict x);
+        int main(void) {return 0;}
+        "
+        HAVE__RESTRICT
+    )
+    check_cxx_source_compiles(
+        "
+        int f(void * __restrict__ x);
+        int main(void) {return 0;}
+        "
+        HAVE__RESTRICT__
+    )
+
+    if (HAVERESTRICT)
+        set(RESTRICT "restrict")
+    elseif(HAVE__RESTRICT)
+        set(RESTRICT "__restrict")
+    elseif(HAVE__RESTRICT__)
+        set(RESTRICT "__restrict__")
+    else()
+        set(RESTRICT "")
+    endif()
+endif()
+
+message(STATUS "Using restrict keyword: " ${RESTRICT})
+add_compile_definitions(RESTRICT=${RESTRICT})

--- a/include/typedefs.hpp
+++ b/include/typedefs.hpp
@@ -9,8 +9,6 @@
 #include <numeric>
 #include <vector>
 
-#define RESTRICT __restrict
-
 namespace NESO::Particles {
 
 static inline int reduce_mul(const int nel, std::vector<int> &values) {


### PR DESCRIPTION
C++ does not define a standardised restrict keyword. This PR adds detection to cmake for a restrict keyword and allows bypass of this detection with a user provided keyword.