### PR TITLE
replaces the std::variant with a custom class

### DIFF
--- a/include/particle_group.hpp
+++ b/include/particle_group.hpp
@@ -7,7 +7,6 @@
 #include <memory>
 #include <mpi.h>
 #include <string>
-#include <variant>
 
 #include "access.hpp"
 #include "cell_dat.hpp"
@@ -31,11 +30,61 @@ namespace NESO::Particles {
 class ParticleSubGroup;
 
 /**
+ * Type to replace std::variant<Sym<INT>, Sym<REAL>> as the version tracking
+ * key as this has been causing segfaults.
+ */
+struct ParticleDatVersionT {
+  Sym<INT> si;
+  Sym<REAL> sr;
+  int index;
+
+  ParticleDatVersionT(Sym<INT> s) {
+    this->si = s;
+    this->index = 0;
+  }
+  ParticleDatVersionT(Sym<REAL> s) {
+    this->sr = s;
+    this->index = 1;
+  }
+  ParticleDatVersionT() { this->index = -1; }
+  ParticleDatVersionT &operator=(const ParticleDatVersionT &) = default;
+  ParticleDatVersionT &operator=(const Sym<INT> &s) {
+    this->si = s;
+    this->index = 0;
+    return *this;
+  };
+  ParticleDatVersionT &operator=(const Sym<REAL> &s) {
+    this->sr = s;
+    this->index = 1;
+    return *this;
+  };
+  bool operator<(const ParticleDatVersionT &v) const {
+    if (v.index == this->index) {
+      if (this->index == -1) {
+        return false;
+      } else if (this->index == 0) {
+        return this->si < v.si;
+      } else {
+        return this->sr < v.sr;
+      }
+    } else {
+      return this->index < v.index;
+    }
+  }
+};
+
+/**
  *  Fundamentally a ParticleGroup is a collection of ParticleDats, domain and a
  *  compute device.
  */
 class ParticleGroup {
   friend class ParticleSubGroup;
+
+protected:
+  // This type should be replaceable with typedef std::variant<Sym<INT>,
+  // Sym<REAL>> ParticleDatVersion; But we see issues with nvc++.
+  typedef ParticleDatVersionT ParticleDatVersion;
+  typedef std::map<ParticleDatVersion, int64_t> ParticleDatVersionTracker;
 
 private:
   int ncell;
@@ -62,10 +111,9 @@ private:
   // members for moving particles between local cells
   CellMove cell_move_ctx;
 
-  std::map<std::variant<Sym<INT>, Sym<REAL>>, std::tuple<int64_t, bool>>
-      particle_dat_versions;
+  std::map<ParticleDatVersion, std::tuple<int64_t, bool>> particle_dat_versions;
 
-  inline void invalidate_callback_inner(std::variant<Sym<INT>, Sym<REAL>> sym,
+  inline void invalidate_callback_inner(ParticleDatVersion sym,
                                         const int mode) {
     std::get<0>(this->particle_dat_versions.at(sym))++;
     std::get<1>(this->particle_dat_versions.at(sym)) = (bool)mode;
@@ -101,15 +149,18 @@ private:
     this->add_invalidate_callback(particle_dat);
     // This store is initialised with 1 and the to test keys should be
     // initialised with 0.
-    this->particle_dat_versions[particle_dat->sym] = {1, false};
+    ParticleDatVersion key{particle_dat->sym};
+    std::tuple<int64_t, bool> value = {1, false};
+    NESOASSERT(this->particle_dat_versions.count(key) == 0,
+               "ParticleDat already in version tracker.");
+    this->particle_dat_versions[key] = value;
   }
 
 protected:
   /**
    * Returns true if the passed version is behind and was updated.
    */
-  inline bool check_validation(
-      std::map<std::variant<Sym<INT>, Sym<REAL>>, int64_t> &to_check) {
+  inline bool check_validation(ParticleDatVersionTracker &to_check) {
     bool updated = false;
     for (auto &item : to_check) {
       const auto &key = item.first;

--- a/include/particle_sub_group.hpp
+++ b/include/particle_sub_group.hpp
@@ -145,7 +145,7 @@ protected:
   std::shared_ptr<BufferDeviceHost<INT>> dh_cells;
   std::shared_ptr<BufferDeviceHost<INT>> dh_layers;
   int npart_local;
-  std::map<std::variant<Sym<INT>, Sym<REAL>>, int64_t> particle_dat_versions;
+  ParticleGroup::ParticleDatVersionTracker particle_dat_versions;
 
   template <template <typename> typename T, typename U>
   inline void check_sym_type(T<U> arg) {

--- a/test/test_particle_sub_group.cpp
+++ b/test/test_particle_sub_group.cpp
@@ -94,6 +94,43 @@ public:
 
 } // namespace
 
+TEST(ParticleSubGroup, version_tracker) {
+
+  ParticleDatVersionT v0;
+  ParticleDatVersionT v1;
+  EXPECT_FALSE(v0 < v1);
+  ParticleDatVersionT r0(Sym<REAL>("A"));
+  ParticleDatVersionT r1(Sym<REAL>("A"));
+  ParticleDatVersionT r2(Sym<REAL>("B"));
+  ParticleDatVersionT i0(Sym<INT>("A"));
+  ParticleDatVersionT i1(Sym<INT>("A"));
+  ParticleDatVersionT i2(Sym<INT>("B"));
+  EXPECT_TRUE(v0 < r0);
+  EXPECT_TRUE(v0 < i0);
+  EXPECT_FALSE(r0 < i0);
+  EXPECT_FALSE(r0 < r1);
+  EXPECT_TRUE(r0 < r2);
+  EXPECT_FALSE(i0 < i1);
+  EXPECT_TRUE(i0 < i2);
+  EXPECT_FALSE(r0 < i0);
+  EXPECT_TRUE(i0 < r0);
+
+  ParticleDatVersionT v2;
+  v2 = Sym<INT>("C");
+  ASSERT_TRUE(v2.index == 0);
+  ASSERT_TRUE(v2.si.name == "C");
+  ParticleDatVersionT v3;
+  v3 = Sym<REAL>("C");
+  ASSERT_TRUE(v3.index == 1);
+  ASSERT_TRUE(v3.sr.name == "C");
+  v2 = v3;
+  ASSERT_TRUE(v2.index == 1);
+  ASSERT_TRUE(v2.sr.name == "C");
+  v3 = Sym<INT>("D");
+  ASSERT_TRUE(v3.index == 0);
+  ASSERT_TRUE(v3.si.name == "D");
+}
+
 TEST(ParticleSubGroup, selector) {
   auto A = particle_loop_common();
   auto domain = A->domain;


### PR DESCRIPTION
std::variant was segfaulting with nvc++ with NESO. Replaces the std::variant logic with a custom struct.