### PR TITLE
Stp/cmake refactor to merge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,69 +1,145 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.24)
 
 project(
-  NESO-Particles
+  NesoParticles
   VERSION 0.0.1
   LANGUAGES CXX C)
 
-set(CMAKE_CXX_STANDARD 17)
-option(ENABLE_NESO_PARTICLES_TESTS "Build unit tests for this project." ON)
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/restrict-keyword.cmake)
+include(GNUInstallDirs)
 
+option(ENABLE_NESO_PARTICLES_TESTS 
+    "Build unit tests for this project." ON)
+option(NESO_PARTICLES_ENABLE_HDF5 "Add HDF5 to targets" ON)
+
+#Create interface/Header onlu library
+add_library(NesoParticles INTERFACE)
+#Alias the name to the namespaces name.
+#Can use in subdirectory or via Confiig files with namespace
+add_library(${PROJECT_NAME}::NesoParticles ALIAS NesoParticles)
+
+#Set standard
+set_property(TARGET NesoParticles PROPERTY CXX_STANDARD 17)
+
+#Makes it easy to install + adds the files to the INCLUDE property of the lib
+#i.e. don't need target_include_dir.. also no GLOBS
+target_sources(NesoParticles
+    PUBLIC
+    FILE_SET public_headers
+    TYPE HEADERS
+    BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
+    FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/cell_dat.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/access.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/boundary_conditions.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/cartesian_mesh.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/cell_binning.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/cell_dat_compression.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/cell_dat.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/cell_dat_move.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/cell_dat_move_impl.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/communication.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/compute_target.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/containers
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/departing_particle_identification.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/departing_particle_identification_impl.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/domain.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/global_mapping.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/global_mapping_impl.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/global_move_exchange.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/global_move.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/local_mapping.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/local_move.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/loop
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/mesh_hierarchy.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/mesh_interface.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/mesh_interface_local_decomp.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/neso_particles.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/packing_unpacking.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/parallel_initialisation.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/particle_dat.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/particle_group.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/particle_io.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/particle_remover.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/particle_set.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/particle_spec.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/particle_sub_group.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/profiling.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/typedefs.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/utility.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/utility_mesh_hierarchy_plotting.hpp
+    )
+
+
+#Don't like this .... TODO: FIXME:
+#Should be a runtime thing?
+if(NESO_PARTICLES_DEVICE_TYPE STREQUAL GPU)
+    target_compile_definitions(NesoParticles INTERFACE NESO_PARTICLES_DEVICE_TYPE_GPU)
+    add_definitions(-DNESO_PARTICLES_DEVICE_TYPE_GPU)
+    message(STATUS "Using NESO_PARTICLES_DEVICE_TYPE_GPU")
+else()
+    target_compile_definitions(NesoParticles INTERFACE NESO_PARTICLES_DEVICE_TYPE_CPU)
+    message(STATUS "Using NESO_PARTICLES_DEVICE_TYPE_CPU")
+endif()
+
+
+#Get MPI 
+find_package(MPI REQUIRED)
+target_link_libraries(NesoParticles INTERFACE MPI::MPI_CXX)
+
+#Get HDF5 if its around
+set(NESO_PARTICLES_USING_HDF5 FALSE)
+if (NESO_PARTICLES_ENABLE_HDF5) 
+    set(HDF5_PREFER_PARALLEL TRUE)
+    find_package(HDF5 REQUIRED)
+    if(HDF5_FOUND AND HDF5_IS_PARALLEL)
+        message(STATUS "Parallel HDF5 found")
+        target_link_libraries(NesoParticles INTERFACE HDF5::HDF5 NesoParticles)
+        target_compile_definitions(NesoParticles INTERFACE NESO_PARTICLES_HDF5)
+        set(NESO_PARTICLES_USING_HDF5 TRUE)
+    else()
+        message( "HDF5 NOT found")
+    endif()
+endif()
+
+#Include the tests
 if(ENABLE_NESO_PARTICLES_TESTS)
   # set build type
   if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "RelWithDebInfo")
     message(STATUS "Set CMAKE_BUILD_TYPE=RelWithDebInfo")
   endif()
-
-  # find NESO-Particles config
-  list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}")
-  find_package(NESO-PARTICLES REQUIRED)
-
-  # Include hipSYCL
-  find_package(hipSYCL 0.9.2 QUIET)
-  if(NOT hipSYCL_FOUND)
-    find_package(IntelDPCPP QUIET)
-    if(NOT IntelDPCPP_FOUND)
-      message(
-        WARNING
-          "Proceeding on the assumption that the CXX compiler is a SYCL2020 compiler."
-      )
-    endif()
-  else()
-    message(STATUS "hipsycl found")
-    set(HIPSYCL_TARGETS "omp")
-  endif(NOT hipSYCL_FOUND)
-
-  # hipsycl, trisycl and computecpp all define an "add_sycl_to_target" for the
-  # compilation of a target
-  if(NOT COMMAND add_sycl_to_target)
-    # Note from hipsycl: "Do not call target_sources after add_sycl_to_target or
-    # dependency tracking on compiler flags will break in subtle ways"
-    function(add_sycl_to_target)
-
-    endfunction()
-  endif()
-
-  if(NESO_PARTICLES_DEVICE_TYPE STREQUAL GPU)
-    add_definitions(-DNESO_PARTICLES_DEVICE_TYPE_GPU)
-    message(STATUS "Using NESO_PARTICLES_DEVICE_TYPE_GPU")
-  else()
-    add_definitions(-DNESO_PARTICLES_DEVICE_TYPE_CPU)
-    message(STATUS "Using NESO_PARTICLES_DEVICE_TYPE_CPU")
-  endif()
-
-  # Include test directory
   enable_testing()
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/test)
 endif()
 
-# put all targets in bin
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/bin)
-# put all libraries in lib
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/lib)
+#install the headers
+install(TARGETS NesoParticles
+    EXPORT ${PROJECT_NAME}_Targets
+    FILE_SET public_headers
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(EXPORT ${PROJECT_NAME}_Targets
+    FILE ${PROJECT_NAME}Targets.cmake
+    NAMESPACE
+    ${PROJECT_NAME}::
+    DESTINATION
+    ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+#create the config.cmake
+include(CMakePackageConfigHelpers)
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    INSTALL_DESTINATION  ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+write_basic_package_version_file(
+    ${PROJECT_NAME}ConfigVersion.cmake
+    VERSION ${PACKAGE_VERSION}
+    COMPATIBILITY AnyNewerVersion)
+#install the config scripts
+install(FILES 
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+    DESTINATION  ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+export(EXPORT ${PROJECT_NAME}_Targets
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}Targets.cmake"
+    NAMESPACE ${PROJECT_NAME}::)
 
-# install the header files
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/include
-        DESTINATION ${CMAKE_INSTALL_PREFIX})
-# install the cmake files
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/cmake DESTINATION ${CMAKE_INSTALL_PREFIX})
+

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,15 @@
+@PACKAGE_INIT@
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+include(CMakeFindDependencyMacro)
+find_dependency(MPI)
+if (NOT COMMAND add_sycl_to_target) 
+    message( WARNING  
+        "Can't find add_sycl_to_target macro SYCL is required for NesoParticles
+        call find_package(<IntelSYCL|AdaptiveCPP|HipSYCL etc etc>) before
+        including this module")
+endif()
+
+if (@NESO_PARTICLES_USING_HDF5@)
+    set(NESO_PARTICLES_WITH_HDF5 TRUE)
+    find_dependency(HDF5)
+endif()

--- a/include/loop/particle_loop.hpp
+++ b/include/loop/particle_loop.hpp
@@ -99,7 +99,9 @@ namespace NESO::Particles::Access {
 /**
  * Generic base type for an access descriptor around an object of type T.
  */
-template <typename T> struct AccessGeneric { T obj; };
+template <typename T> struct AccessGeneric {
+  T obj;
+};
 
 /**
  *  Read access descriptor.
@@ -329,7 +331,9 @@ namespace {
  * LoopParameter is the pointer type that points to the data for all cells,
  * layers and components.
  */
-template <typename T> struct LoopParameter { using type = void *; };
+template <typename T> struct LoopParameter {
+  using type = void *;
+};
 /**
  *  Loop parameter for read access of a ParticleDat via Sym.
  */
@@ -415,7 +419,9 @@ template <class T> using loop_parameter_t = typename LoopParameter<T>::type;
  * The KernelParameter types define the types passed to the kernel for each
  * data structure type for each access descriptor.
  */
-template <typename T> struct KernelParameter { using type = void; };
+template <typename T> struct KernelParameter {
+  using type = void;
+};
 
 /**
  *  KernelParameter type for read-only access to a ParticleDat - via Sym.

--- a/include/particle_dat.hpp
+++ b/include/particle_dat.hpp
@@ -414,13 +414,13 @@ public:
    *  @returns Particle Loop iteration set size.
    */
   inline INT get_particle_loop_iter_range() {
-    //#ifdef NESO_PARTICLES_ITER_PARTICLES
-    //    return this->cell_dat.ncells * this->cell_dat.get_nrow_max();
-    //#else // case for NESO_PARTICLES_ITER_CELLS
-    //    const auto n = this->cell_dat.get_nrow_max();
-    //    const auto m = (n/NESO_PARTICLES_BLOCK_SIZE) + ((INT) (n %
-    //    NESO_PARTICLES_BLOCK_SIZE > 0)); return this->cell_dat.ncells * m;
-    //#endif
+    // #ifdef NESO_PARTICLES_ITER_PARTICLES
+    //     return this->cell_dat.ncells * this->cell_dat.get_nrow_max();
+    // #else // case for NESO_PARTICLES_ITER_CELLS
+    //     const auto n = this->cell_dat.get_nrow_max();
+    //     const auto m = (n/NESO_PARTICLES_BLOCK_SIZE) + ((INT) (n %
+    //     NESO_PARTICLES_BLOCK_SIZE > 0)); return this->cell_dat.ncells * m;
+    // #endif
     //
 
     INT iter_range =

--- a/include/typedefs.hpp
+++ b/include/typedefs.hpp
@@ -129,9 +129,9 @@ template <typename... T> inline void nprint(T... args) {
 //#define NESO_PARTICLES_KERNEL_START                                            \
 //  const int neso_npart = pl_npart_cell[idx];                                   \
 //  for (int neso_layer = 0; neso_layer < neso_npart; neso_layer++) {
-//#define NESO_PARTICLES_KERNEL_END }
-//#define NESO_PARTICLES_KERNEL_CELL idx
-//#define NESO_PARTICLES_KERNEL_LAYER neso_layer
+// #define NESO_PARTICLES_KERNEL_END }
+// #define NESO_PARTICLES_KERNEL_CELL idx
+// #define NESO_PARTICLES_KERNEL_LAYER neso_layer
 
 #define NESO_PARTICLES_KERNEL_START                                            \
   const int neso_cell = (((INT)idx) / pl_stride);                              \
@@ -160,7 +160,7 @@ template <typename... T> inline void nprint(T... args) {
 
 #endif
 
-//#define DEBUG_OOB_CHECK
+// #define DEBUG_OOB_CHECK
 #define DEBUG_OOB_WIDTH 1000
 
 /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,69 +1,114 @@
-cmake_minimum_required(VERSION 3.14)
-project(NESO-Particles VERSION 0.0.1)
+#No need should be inherited from neso-particles
+#set(CMAKE_CXX_STANDARD 17)
 
-# GoogleTest requires at least C++11 DataParallel C++ requires at least C++17
-set(CMAKE_CXX_STANDARD 17)
-
-add_definitions(-DGPU_SELECTOR=0)
+#add_definitions(-DGPU_SELECTOR=0)
 
 find_package(GTest QUIET)
 
 if(NOT GTest_FOUND)
-  include(FetchContent)
-  FetchContent_Declare(
-    googletest
-    URL https://github.com/google/googletest/archive/054a986a8513149e8374fc669a5fe40117ca6b41.zip
-  )
-  # For Windows: Prevent overriding the parent project's compiler/linker
-  # settings
-  set(gtest_force_shared_crt
-      ON
-      CACHE BOOL "" FORCE)
-  FetchContent_MakeAvailable(googletest)
+    include(FetchContent)
+    FetchContent_Declare(
+        googletest
+        URL https://github.com/google/googletest/archive/054a986a8513149e8374fc669a5fe40117ca6b41.zip
+        DOWNLOAD_EXTRACT_TIMESTAMP FALSE
+        )
+    # For Windows: Prevent overriding the parent project's compiler/linker
+    # settings
+    set(gtest_force_shared_crt
+        ON
+        CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(googletest)
 endif()
+
+
+#Find SYCL
+if (COMMAND add_sycl_to_target) 
+    #Not perfect method but if in a submodule dont want to use a different
+    #sycl
+    message("add_sycl_to_target macro exists")
+else()
+    message("add_sycl_to_target macro NOT FOUND looking for SYCL package...")
+    find_package(hipSYCL 0.9.2 QUIET)
+    if(NOT hipSYCL_FOUND)
+        find_package(IntelDPCPP QUIET)
+        if(NOT IntelDPCPP_FOUND)
+            message(
+                WARNING
+                "Proceeding on the assumption that the CXX compiler is a SYCL2020 compiler."
+                )
+        endif()
+    else()
+        message(STATUS "hipsycl found")
+        set(HIPSYCL_TARGETS "omp")
+    endif(NOT hipSYCL_FOUND)
+
+    # hipsycl, trisycl and computecpp all define an "add_sycl_to_target" for the
+    # compilation of a target
+    if(NOT COMMAND add_sycl_to_target)
+        # Note from hipsycl: "Do not call target_sources after add_sycl_to_target or
+        # dependency tracking on compiler flags will break in subtle ways"
+        function(add_sycl_to_target)
+
+        endfunction()
+    endif()
+endif()
+
+set(TEST_SRCS 
+    test_boundary_pbc.cpp
+    test_buffers.cpp
+    test_cell_dat.cpp
+    test_error_propagate.cpp
+    test_examples.cpp
+    test_global_array.cpp
+    test_int_key_value_map.cpp
+    test_local_array.cpp
+    test_local_decomp_mesh.cpp
+    test_mesh_hierarchy.cpp
+    test_parallel_initialisation.cpp
+    test_particle_dat.cpp
+    test_particle_group_cell_move.cpp
+    test_particle_group.cpp
+    test_particle_group_global_move.cpp
+    test_particle_group_hybrid_move.cpp
+    test_particle_group_local_move.cpp
+    test_particle_group_stencil_move.cpp
+    test_particle_h5part.cpp
+    test_particle_loop.cpp
+    test_particle_remover.cpp
+    test_particle_set.cpp
+    test_particle_sub_group.cpp
+    test_sycl_target.cpp
+    test_tuple.cpp
+    test_utility.cpp)
 
 set(EXECUTABLE testNESOParticles)
 set(TEST_MAIN ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
-
-# List test source files
-file(GLOB TEST_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/test_*.cpp
-     ${CMAKE_CURRENT_SOURCE_DIR}/*_test.cpp)
-
-# options common to both fftw/mkl
-set(LINK_LIBRARIES_COMMON
-    ${MPI_CXX_LINK_FLAGS} ${MPI_CXX_LIBRARIES} ${NESO_PARTICLES_LIBRARIES}
-    ${NESO_PARTICLES_LINK_FLAGS} GTest::gtest)
-
-set(INCLUDE_DIRECTORIES_COMMON
-    ${CMAKE_SOURCE_DIR}/include ${MPI_CXX_INCLUDE_PATH}
-    ${NESO_PARTICLES_INCLUDE_PATH})
-
 # Build the tests individually
 include(GoogleTest)
 foreach(TEST ${TEST_SRCS})
-  get_filename_component(TEST_NAME ${TEST} NAME_WLE)
-  message(STATUS "Found test - ${TEST_NAME}")
-  set(TEST_LIST ${TEST_LIST} ${TEST})
+    get_filename_component(TEST_NAME ${TEST} NAME_WLE)
+    message(STATUS "Found test - ${TEST_NAME}")
+    set(TEST_LIST ${TEST_LIST} ${TEST})
 
-  set(TEST_SOURCES ${TEST_MAIN} ${TEST})
-  add_executable(${TEST_NAME} ${TEST_SOURCES})
+    set(TEST_SOURCES ${TEST_MAIN} ${TEST})
+    add_executable(${TEST_NAME} ${TEST_SOURCES})
+    target_link_libraries(${TEST_NAME} PRIVATE NesoParticles GTest::gtest)
+    target_compile_definitions(${TEST_NAME} PRIVATE GPU_SELECTOR=0)
 
-  target_link_libraries(${TEST_NAME} PRIVATE ${LINK_LIBRARIES_COMMON})
-  target_include_directories(${TEST_NAME} PRIVATE ${INCLUDE_DIRECTORIES_COMMON})
-
-  add_sycl_to_target(TARGET ${TEST_NAME} SOURCES ${TEST_SOURCES})
-  gtest_add_tests(TARGET ${TEST_NAME})
+    add_sycl_to_target(TARGET ${TEST_NAME} SOURCES ${TEST_SOURCES})
+    gtest_add_tests(TARGET ${TEST_NAME})
 endforeach()
 
 # Build a global test suite
 add_executable(${EXECUTABLE} ${TEST_MAIN} ${TEST_LIST})
 
-target_include_directories(${EXECUTABLE} PRIVATE ${INCLUDE_DIRECTORIES_COMMON})
-target_link_libraries(${EXECUTABLE} PRIVATE ${LINK_LIBRARIES_COMMON})
+target_link_libraries(${EXECUTABLE} PRIVATE NesoParticles GTest::gtest)
+target_compile_definitions(${EXECUTABLE} PRIVATE GPU_SELECTOR=0)
+
 
 # define the test executable as a sycl target
 add_sycl_to_target(TARGET ${EXECUTABLE} SOURCES ${TEST_MAIN} ${TEST_LIST})
 gtest_add_tests(TARGET ${EXECUTABLE} SOURCES ${TEST_MAIN})
 
 # install the combined test binary
-install(TARGETS ${EXECUTABLE} DESTINATION bin)
+#install(TARGETS ${EXECUTABLE} DESTINATION bin)


### PR DESCRIPTION
Updates to cmake to export itself in "modern" way
can be used as submodule or package now

Is a breaking change, have to update NESO (see https://github.com/ExCALIBUR-NEPTUNE/NESO/compare/stp/cmake_refactor_to_merge?expand=1)