### PR TITLE
Allow vector args to SymStore

### DIFF
--- a/include/neso_particles/particle_group.hpp
+++ b/include/neso_particles/particle_group.hpp
@@ -825,7 +825,7 @@ public:
    *  @param args Sym<REAL> or Sym<INT> instances that indicate which particle
    *  data to print.
    */
-  template <typename... T> inline void print(T... args);
+  template <typename... T> inline void print(T &&...args);
 
   /**
    *  Print all particle data for a particle.

--- a/include/neso_particles/particle_group_impl.hpp
+++ b/include/neso_particles/particle_group_impl.hpp
@@ -205,9 +205,9 @@ inline void ParticleGroup::local_move() {
   this->invalidate_group_version();
 }
 
-template <typename... T> inline void ParticleGroup::print(T... args) {
+template <typename... T> inline void ParticleGroup::print(T &&...args) {
 
-  SymStore print_spec(args...);
+  SymStore print_spec(std::forward<args>...);
 
   std::cout << "==============================================================="
                "================="

--- a/include/neso_particles/particle_group_impl.hpp
+++ b/include/neso_particles/particle_group_impl.hpp
@@ -207,7 +207,7 @@ inline void ParticleGroup::local_move() {
 
 template <typename... T> inline void ParticleGroup::print(T &&...args) {
 
-  SymStore print_spec(std::forward<args>...);
+  SymStore print_spec(std::forward<T>(args)...);
 
   std::cout << "==============================================================="
                "================="

--- a/include/neso_particles/particle_io.hpp
+++ b/include/neso_particles/particle_io.hpp
@@ -219,9 +219,10 @@ public:
    *  indicating which ParticleDats are to be written.
    */
   template <typename... T>
-  H5Part(std::string filename, ParticleGroupSharedPtr particle_group, T... args)
+  H5Part(std::string filename, ParticleGroupSharedPtr particle_group,
+         T &&...args)
       : filename(filename), comm_pair(particle_group->sycl_target->comm_pair),
-        sym_store(args...), particle_group(particle_group),
+        sym_store(std::forward<T>(args)...), particle_group(particle_group),
         multi_dim_mode(false) {
     this->plist_id = H5Pcreate(H5P_FILE_ACCESS);
     H5CHK(H5Pset_fapl_mpio(this->plist_id, this->comm_pair.comm_parent,

--- a/include/neso_particles/particle_spec.hpp
+++ b/include/neso_particles/particle_spec.hpp
@@ -208,6 +208,12 @@ private:
     this->syms_int.push_back(pp);
     this->push(std::forward<T>(args)...);
   }
+  template <typename... T> void push(std::vector<Sym<REAL>> &pp) {
+    this->syms_real.insert(this->syms_real.end(), pp.begin(), pp.end());
+  }
+  template <typename... T> void push(std::vector<Sym<INT>> &pp) {
+    this->syms_int.insert(this->syms_int.end(), pp.begin(), pp.end());
+  }
   template <typename... T> void push(std::vector<Sym<REAL>> &pp, T &&...args) {
     this->syms_real.insert(this->syms_real.end(), pp.begin(), pp.end());
     this->push(std::forward<T>(args)...);

--- a/include/neso_particles/particle_spec.hpp
+++ b/include/neso_particles/particle_spec.hpp
@@ -195,16 +195,26 @@ public:
  */
 class SymStore {
 private:
-  template <typename... T> void push(T... args) { this->push(args...); }
+  template <typename... T> void push(T &&...args) {
+    this->push(std::forward<T>(args)...);
+  }
   void push(Sym<REAL> pp) { this->syms_real.push_back(pp); }
   void push(Sym<INT> pp) { this->syms_int.push_back(pp); }
-  template <typename... T> void push(Sym<REAL> pp, T... args) {
+  template <typename... T> void push(Sym<REAL> pp, T &&...args) {
     this->syms_real.push_back(pp);
-    this->push(args...);
+    this->push(std::forward<T>(args)...);
   }
-  template <typename... T> void push(Sym<INT> pp, T... args) {
+  template <typename... T> void push(Sym<INT> pp, T &&...args) {
     this->syms_int.push_back(pp);
-    this->push(args...);
+    this->push(std::forward<T>(args)...);
+  }
+  template <typename... T> void push(std::vector<Sym<REAL>> &pp, T &&...args) {
+    this->syms_real.insert(this->syms_real.end(), pp.begin(), pp.end());
+    this->push(std::forward<T>(args)...);
+  }
+  template <typename... T> void push(std::vector<Sym<INT>> &pp, T &&...args) {
+    this->syms_int.insert(this->syms_int.end(), pp.begin(), pp.end());
+    this->push(std::forward<T>(args)...);
   }
 
 public:
@@ -216,9 +226,12 @@ public:
    *  Constructor for SymStore should be called with a list of arguments which
    *  are Sym instances.
    *
-   *  @param args Passed arguments should be Sym<REAL> or Sym<INT>.
+   *  @param args Passed arguments should be Sym<REAL>, std::vector<Sym<REAL>>,
+   * Sym<INT> or std::vector<Sym<INT>>.
    */
-  template <typename... T> SymStore(T... args) { this->push(args...); }
+  template <typename... T> SymStore(T &&...args) {
+    this->push(std::forward<T>(args)...);
+  };
 
   SymStore(){};
   ~SymStore(){};

--- a/include/neso_particles/particle_sub_group/particle_sub_group_base.hpp
+++ b/include/neso_particles/particle_sub_group/particle_sub_group_base.hpp
@@ -353,12 +353,12 @@ public:
    *  @param args Sym<REAL> or Sym<INT> instances that indicate which particle
    *  data to print.
    */
-  template <typename... T> inline void print(T... args) {
+  template <typename... T> inline void print(T &&...args) {
     if (this->is_whole_particle_group) {
-      return this->particle_group->print(args...);
+      return this->particle_group->print(std::forward<T>(args)...);
     } else {
       this->create_if_required();
-      SymStore print_spec(args...);
+      SymStore print_spec(std::forward<T>(args)...);
 
       for (auto &symx : print_spec.syms_real) {
         NESOASSERT(this->particle_group->contains_dat(symx), "Sym not found.");


### PR DESCRIPTION
This PR allows users to pass std::vector<Sym<REAL/INT> to SymStore in order to allow runtime flexibility in printing particles.
Linked from https://github.com/ExCALIBUR-NEPTUNE/NESO/pull/284