### PR TITLE
Fix ProductMatrix::reset not being called correctly.

### DIFF
--- a/include/neso_particles/containers/descendant_products.hpp
+++ b/include/neso_particles/containers/descendant_products.hpp
@@ -191,10 +191,12 @@ public:
    * @param num_particles Number of parent particles space is required for.
    */
   virtual inline void reset(const int num_particles) override {
+    NESOASSERT(num_particles >= 0,
+               "A negative number of particles does not make sense.");
     this->num_particles = num_particles;
+    const int num_products = num_particles * num_products_per_parent;
+    ProductMatrix::reset(num_products);
     if (num_particles > 0) {
-      const int num_products = num_particles * num_products_per_parent;
-      ProductMatrix::reset(num_products);
       this->d_parent_cells->realloc_no_copy(num_products);
       this->d_parent_layers->realloc_no_copy(num_products);
       auto e0 = this->sycl_target->queue.fill(

--- a/include/neso_particles/containers/product_matrix.hpp
+++ b/include/neso_particles/containers/product_matrix.hpp
@@ -481,7 +481,7 @@ public:
    */
   ProductMatrix(SYCLTargetSharedPtr sycl_target,
                 std::shared_ptr<ProductMatrixSpec> spec)
-      : sycl_target(sycl_target), spec(spec) {
+      : sycl_target(sycl_target), num_products(0), spec(spec) {
 
     NESOASSERT(sycl_target != nullptr, "sycl_target is nullptr.");
     this->d_data_real = std::make_shared<BufferDevice<REAL>>(sycl_target, 1);
@@ -518,6 +518,8 @@ public:
   virtual inline void reset(const int num_products) {
     const auto spec = this->spec.get();
     NESOASSERT(spec != nullptr, "ProductMatrix is not initialised.");
+    NESOASSERT(num_products >= 0,
+               "A negative number of products does not make sense.");
     this->num_products = num_products;
     if (num_products > 0) {
       this->d_data_real->realloc_no_copy(num_products *

--- a/test/test_product_matrix.cpp
+++ b/test/test_product_matrix.cpp
@@ -433,6 +433,31 @@ struct DescendantProductsTest : public DescendantProducts {
   inline std::vector<INT> get_layers() { return this->d_parent_layers->get(); }
 };
 
+TEST(DescendantProducts, reset) {
+
+  auto product_spec = product_matrix_spec(ParticleSpec(
+      ParticleProp(Sym<REAL>("P2"), ndim), ParticleProp(Sym<INT>("MARKER"), 2),
+      ParticleProp(Sym<INT>("PARENT"), 2)));
+
+  auto sycl_target = std::make_shared<SYCLTarget>(0, MPI_COMM_WORLD);
+
+  const int num_products_per_particle = 7;
+  auto dp = std::make_shared<DescendantProductsTest>(sycl_target, product_spec,
+                                                     num_products_per_particle);
+  ASSERT_EQ(dp->num_particles, 0);
+  ASSERT_EQ(dp->num_products, 0);
+
+  dp->reset(9);
+  ASSERT_EQ(dp->num_particles, 9);
+  ASSERT_EQ(dp->num_products, 9 * 7);
+
+  dp->reset(0);
+  ASSERT_EQ(dp->num_particles, 0);
+  ASSERT_EQ(dp->num_products, 0);
+
+  sycl_target->free();
+}
+
 TEST(DescendantProducts, parents) {
   auto A = particle_loop_common();
   auto domain = A->domain;


### PR DESCRIPTION
* Fix ProductMatrix::reset not being called correctly when num_particles is zero.
* Should fix segfault here: https://github.com/UKAEA-Edge-Code/Reactions/pull/92#pullrequestreview-2759964492