### PR TITLE
Fix  `-Wall`  warning

### DIFF
--- a/include/neso_particles/mesh_interface_local_decomp.hpp
+++ b/include/neso_particles/mesh_interface_local_decomp.hpp
@@ -35,7 +35,7 @@ public:
   /// Vector of nearby ranks which local exchange patterns can be setup with.
   std::vector<int> neighbour_ranks;
 
-  ~LocalDecompositionHMesh() {}
+  virtual ~LocalDecompositionHMesh() {}
 
   /**
    * Create a new instance.


### PR DESCRIPTION
destructor needs to be virtual or apparently undefined behaviour if destructor called via base class.