### PR TITLE
ParticleDat <-> EphemeralDat copy functions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ endif()
 
 set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 set(SRC_FILES
+    ${SRC_DIR}/algorithms/particle_data_movement.cpp
     ${SRC_DIR}/algorithms/reduce_dat_cellwise.cpp
     ${SRC_DIR}/external_interfaces/petsc/boundary_interaction/boundary_interaction_2d.cpp
     ${SRC_DIR}/external_interfaces/petsc/boundary_interaction/boundary_interaction_common.cpp
@@ -120,6 +121,7 @@ set(HEADER_FILES
     ${INCLUDE_DIR}/neso_particles.hpp
     ${INCLUDE_DIR_NESO_PARTICLES}/access.hpp
     ${INCLUDE_DIR_NESO_PARTICLES}/algorithms/algorithms.hpp
+    ${INCLUDE_DIR_NESO_PARTICLES}/algorithms/particle_data_movement.hpp
     ${INCLUDE_DIR_NESO_PARTICLES}/algorithms/reduce_dat_cellwise.hpp
     ${INCLUDE_DIR_NESO_PARTICLES}/cartesian_mesh/cartesian_h_mesh.hpp
     ${INCLUDE_DIR_NESO_PARTICLES}/cartesian_mesh/cartesian_cell_bin.hpp

--- a/include/neso_particles/algorithms/algorithms.hpp
+++ b/include/neso_particles/algorithms/algorithms.hpp
@@ -1,6 +1,7 @@
 #ifndef _NESO_PARTICLES_ALGORITHMS_ALGORITHMS_HPP_
 #define _NESO_PARTICLES_ALGORITHMS_ALGORITHMS_HPP_
 
+#include "particle_data_movement.hpp"
 #include "reduce_dat_cellwise.hpp"
 
 #endif

--- a/include/neso_particles/algorithms/particle_data_movement.hpp
+++ b/include/neso_particles/algorithms/particle_data_movement.hpp
@@ -1,0 +1,109 @@
+#ifndef _NESO_PARTICLES_ALGORITHMS_PARTICLE_DATA_MOVEMENT_HPP_
+#define _NESO_PARTICLES_ALGORITHMS_PARTICLE_DATA_MOVEMENT_HPP_
+
+#include "../compute_target.hpp"
+#include "../particle_sub_group/particle_sub_group.hpp"
+
+namespace NESO::Particles {
+
+/**
+ * Copy all particle data from an EphemeralDat to a ParticleDat. The source and
+ * destination dats must exist and have the same number of components. Source
+ * and destination dats may share the same name.
+ *
+ * @param particle_sub_group ParticleSubGroup containing source and destination
+ * dats.
+ * @param sym_src Source EphemeralDat name.
+ * @param sym_dst Destination ParticleDat name.
+ */
+template <typename T>
+void copy_ephemeral_dat_to_particle_dat(
+    ParticleSubGroupSharedPtr particle_sub_group, Sym<T> sym_src,
+    Sym<T> sym_dst) {
+
+  auto particle_group = get_particle_group(particle_sub_group);
+  NESOASSERT(particle_sub_group->contains_ephemeral_dat(sym_src),
+             "ParticleSubGroup does not contain an EphemeralDat with name: " +
+                 sym_src.name);
+  NESOASSERT(particle_group->contains_dat(sym_dst),
+             "ParticleGroup does not contain a ParticleDat with name: " +
+                 sym_dst.name);
+
+  auto dat_src = particle_sub_group->get_ephemeral_dat(sym_src);
+  auto dat_dst = particle_group->get_dat(sym_dst);
+
+  NESOASSERT(
+      dat_src->ncomp == dat_dst->ncomp,
+      "Missmatch between number of components in source and destination.");
+
+  const int k_ncomp = dat_src->ncomp;
+  particle_loop(
+      "copy_ephemeral_dat_to_particle_dat", particle_sub_group,
+      [=](auto SRC, auto DST) {
+        for (int cx = 0; cx < k_ncomp; cx++) {
+          DST.at(cx) = SRC.at_ephemeral(cx);
+        }
+      },
+      Access::read(dat_src), Access::write(dat_dst))
+      ->execute();
+}
+
+extern template void
+copy_ephemeral_dat_to_particle_dat(ParticleSubGroupSharedPtr particle_sub_group,
+                                   Sym<INT> sym_src, Sym<INT> sym_dst);
+extern template void
+copy_ephemeral_dat_to_particle_dat(ParticleSubGroupSharedPtr particle_sub_group,
+                                   Sym<REAL> sym_src, Sym<REAL> sym_dst);
+
+/**
+ * Copy all particle data from a ParticleDat to an EphemeralDat. The source and
+ * destination dats must exist and have the same number of components. Source
+ * and destination dats may share the same name.
+ *
+ * @param particle_sub_group ParticleSubGroup containing source and destination
+ * dats.
+ * @param sym_src Source ParticleDat name.
+ * @param sym_dst Destination EphemeralDat name.
+ */
+template <typename T>
+void copy_particle_dat_to_ephemeral_dat(
+    ParticleSubGroupSharedPtr particle_sub_group, Sym<T> sym_src,
+    Sym<T> sym_dst) {
+
+  auto particle_group = get_particle_group(particle_sub_group);
+  NESOASSERT(particle_sub_group->contains_ephemeral_dat(sym_dst),
+             "ParticleSubGroup does not contain an EphemeralDat with name: " +
+                 sym_dst.name);
+  NESOASSERT(particle_group->contains_dat(sym_src),
+             "ParticleGroup does not contain a ParticleDat with name: " +
+                 sym_src.name);
+
+  auto dat_src = particle_group->get_dat(sym_src);
+  auto dat_dst = particle_sub_group->get_ephemeral_dat(sym_dst);
+
+  NESOASSERT(
+      dat_src->ncomp == dat_dst->ncomp,
+      "Missmatch between number of components in source and destination.");
+
+  const int k_ncomp = dat_src->ncomp;
+  particle_loop(
+      "copy_particle_dat_to_ephemeral_dat", particle_sub_group,
+      [=](auto SRC, auto DST) {
+        for (int cx = 0; cx < k_ncomp; cx++) {
+          DST.at_ephemeral(cx) = SRC.at(cx);
+        }
+      },
+      Access::read(dat_src), Access::write(dat_dst))
+      ->execute();
+}
+
+extern template void
+copy_particle_dat_to_ephemeral_dat(ParticleSubGroupSharedPtr particle_sub_group,
+                                   Sym<INT> sym_src, Sym<INT> sym_dst);
+extern template void
+copy_particle_dat_to_ephemeral_dat(ParticleSubGroupSharedPtr particle_sub_group,
+                                   Sym<REAL> sym_src, Sym<REAL> sym_dst);
+
+} // namespace NESO::Particles
+
+#endif

--- a/src/algorithms/particle_data_movement.cpp
+++ b/src/algorithms/particle_data_movement.cpp
@@ -1,0 +1,19 @@
+#include <neso_particles/algorithms/particle_data_movement.hpp>
+
+namespace NESO::Particles {
+
+template void
+copy_ephemeral_dat_to_particle_dat(ParticleSubGroupSharedPtr particle_sub_group,
+                                   Sym<INT> sym_src, Sym<INT> sym_dst);
+template void
+copy_ephemeral_dat_to_particle_dat(ParticleSubGroupSharedPtr particle_sub_group,
+                                   Sym<REAL> sym_src, Sym<REAL> sym_dst);
+
+template void
+copy_particle_dat_to_ephemeral_dat(ParticleSubGroupSharedPtr particle_sub_group,
+                                   Sym<INT> sym_src, Sym<INT> sym_dst);
+template void
+copy_particle_dat_to_ephemeral_dat(ParticleSubGroupSharedPtr particle_sub_group,
+                                   Sym<REAL> sym_src, Sym<REAL> sym_dst);
+
+} // namespace NESO::Particles

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,7 @@ set(TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(TEST_SRCS
     ${TEST_DIR}/test_algorithms_a.cpp
     ${TEST_DIR}/test_algorithms_b.cpp
+    ${TEST_DIR}/test_algorithms_c.cpp
     ${TEST_DIR}/test_boundary_pbc.cpp
     ${TEST_DIR}/test_boundary_truncation.cpp
     ${TEST_DIR}/test_boundary_reflection.cpp

--- a/test/test_algorithms_c.cpp
+++ b/test/test_algorithms_c.cpp
@@ -1,0 +1,124 @@
+#include "include/test_neso_particles.hpp"
+
+TEST(Algorithms, copy_ephemeral_dat_to_particle_dat) {
+  auto [A, sycl_target, cell_count_t] = particle_loop_common_2d(27, 16, 32);
+
+  A->add_particle_dat(Sym<INT>("FOO"), 4);
+  A->add_particle_dat(Sym<INT>("BAR"), 4);
+  auto aa = particle_sub_group(
+      A, [=](auto ID) { return ID.at(0) % 2; }, Access::read(Sym<INT>("ID")));
+
+  aa->add_ephemeral_dat(Sym<INT>("FOO"), 4);
+
+  particle_loop(
+      aa,
+      [=](auto INDEX, auto FOO) {
+        for (int dx = 0; dx < 4; dx++) {
+          FOO.at_ephemeral(dx) = (INDEX.get_local_linear_index() + dx * 7) % 31;
+        }
+      },
+      Access::read(ParticleLoopIndex{}), Access::write(Sym<INT>("FOO")))
+      ->execute();
+
+  copy_ephemeral_dat_to_particle_dat(aa, Sym<INT>("FOO"), Sym<INT>("FOO"));
+
+  auto ep = ErrorPropagate(sycl_target);
+  auto k_ep = ep.device_ptr();
+
+  particle_loop(
+      A,
+      [=](auto INDEX, auto ID, auto FOO) {
+        if (ID.at(0) % 2) {
+          for (int dx = 0; dx < 4; dx++) {
+            NESO_KERNEL_ASSERT(
+                FOO.at(dx) == (INDEX.get_local_linear_index() + dx * 7) % 31,
+                k_ep);
+          }
+        }
+      },
+      Access::read(ParticleLoopIndex{}), Access::read(Sym<INT>("ID")),
+      Access::read(Sym<INT>("FOO")))
+      ->execute();
+
+  ASSERT_FALSE(ep.get_flag());
+
+  copy_ephemeral_dat_to_particle_dat(aa, Sym<INT>("FOO"), Sym<INT>("BAR"));
+
+  particle_loop(
+      A,
+      [=](auto INDEX, auto ID, auto BAR) {
+        if (ID.at(0) % 2) {
+          for (int dx = 0; dx < 4; dx++) {
+            NESO_KERNEL_ASSERT(
+                BAR.at(dx) == (INDEX.get_local_linear_index() + dx * 7) % 31,
+                k_ep);
+          }
+        }
+      },
+      Access::read(ParticleLoopIndex{}), Access::read(Sym<INT>("ID")),
+      Access::read(Sym<INT>("BAR")))
+      ->execute();
+
+  ASSERT_FALSE(ep.get_flag());
+
+  sycl_target->free();
+  A->domain->mesh->free();
+}
+
+TEST(Algorithms, copy_particle_dat_to_ephemeral_dat) {
+  auto [A, sycl_target, cell_count_t] = particle_loop_common_2d(27, 16, 32);
+
+  A->add_particle_dat(Sym<INT>("FOO"), 4);
+  auto aa = particle_sub_group(
+      A, [=](auto ID) { return ID.at(0) % 2; }, Access::read(Sym<INT>("ID")));
+  aa->add_ephemeral_dat(Sym<INT>("FOO"), 4);
+  aa->add_ephemeral_dat(Sym<INT>("BAR"), 4);
+
+  particle_loop(
+      A,
+      [=](auto INDEX, auto FOO) {
+        for (int dx = 0; dx < 4; dx++) {
+          FOO.at(dx) = (INDEX.get_local_linear_index() + dx * 7) % 31;
+        }
+      },
+      Access::read(ParticleLoopIndex{}), Access::write(Sym<INT>("FOO")))
+      ->execute();
+
+  copy_particle_dat_to_ephemeral_dat(aa, Sym<INT>("FOO"), Sym<INT>("FOO"));
+
+  auto ep = ErrorPropagate(sycl_target);
+  auto k_ep = ep.device_ptr();
+
+  particle_loop(
+      aa,
+      [=](auto INDEX, auto FOO) {
+        for (int dx = 0; dx < 4; dx++) {
+          NESO_KERNEL_ASSERT(FOO.at_ephemeral(dx) ==
+                                 (INDEX.get_local_linear_index() + dx * 7) % 31,
+                             k_ep);
+        }
+      },
+      Access::read(ParticleLoopIndex{}), Access::read(Sym<INT>("FOO")))
+      ->execute();
+
+  ASSERT_FALSE(ep.get_flag());
+
+  copy_particle_dat_to_ephemeral_dat(aa, Sym<INT>("FOO"), Sym<INT>("BAR"));
+
+  particle_loop(
+      aa,
+      [=](auto INDEX, auto BAR) {
+        for (int dx = 0; dx < 4; dx++) {
+          NESO_KERNEL_ASSERT(BAR.at_ephemeral(dx) ==
+                                 (INDEX.get_local_linear_index() + dx * 7) % 31,
+                             k_ep);
+        }
+      },
+      Access::read(ParticleLoopIndex{}), Access::read(Sym<INT>("BAR")))
+      ->execute();
+
+  ASSERT_FALSE(ep.get_flag());
+
+  sycl_target->free();
+  A->domain->mesh->free();
+}


### PR DESCRIPTION
* Added helper functions (and tests) for directly copying particle data between EphemeralDats and ParticleDats.