### PR TITLE
Fix CopySelector for when the child is a static sub group.

### DIFF
--- a/src/particle_sub_group/copy_selector.cpp
+++ b/src/particle_sub_group/copy_selector.cpp
@@ -1,5 +1,6 @@
 #include <neso_particles/particle_sub_group/copy_selector.hpp>
 #include <neso_particles/particle_sub_group/particle_sub_group.hpp>
+#include <numeric>
 
 namespace NESO::Particles {
 namespace ParticleSubGroupImplementation {
@@ -7,7 +8,61 @@ void CopySelector::create(Selection *created_selection) {
   auto sycl_target = this->particle_group->sycl_target;
   this->parent->create_if_required();
   auto parent_selection = this->parent->get_selection();
-  *created_selection = parent_selection;
+
+  auto [h_npart_cell_ptr, d_npart_cell_ptr, h_npart_cell_es_ptr,
+        d_npart_cell_es_ptr] = this->sub_group_particle_map->get_helper_ptrs();
+
+  const auto cell_count = parent_selection.ncell;
+
+  auto k_npart_cell_ptr = d_npart_cell_ptr;
+  auto k_npart_cell_es_ptr = d_npart_cell_es_ptr;
+  auto k_parent_npart_cell_ptr = parent_selection.d_npart_cell;
+  auto k_parent_npart_cell_es_ptr = parent_selection.d_npart_cell_es;
+
+  auto e0 =
+      sycl_target->queue.parallel_for(sycl::range<1>(cell_count), [=](auto ix) {
+        k_npart_cell_ptr[ix] = k_parent_npart_cell_ptr[ix];
+        k_npart_cell_es_ptr[ix] = k_parent_npart_cell_es_ptr[ix];
+      });
+  std::memcpy(h_npart_cell_ptr, parent_selection.h_npart_cell,
+              cell_count * sizeof(int));
+  std::exclusive_scan(h_npart_cell_ptr, h_npart_cell_ptr + cell_count,
+                      h_npart_cell_es_ptr, static_cast<INT>(0));
+
+  this->sub_group_particle_map->create(0, cell_count, h_npart_cell_ptr,
+                                       h_npart_cell_es_ptr);
+  auto k_cell_starts_ptr = this->sub_group_particle_map->d_cell_starts->ptr;
+  auto k_cell_starts_parent_ptr =
+      parent_selection.d_map_cells_to_particles.map_ptr;
+
+  const std::size_t local_size =
+      sycl_target->parameters->template get<SizeTParameter>("LOOP_LOCAL_SIZE")
+          ->value;
+
+  e0.wait_and_throw();
+  auto e1 = sycl_target->queue.parallel_for(
+      sycl_target->device_limits.validate_nd_range(sycl::nd_range<2>(
+          sycl::range<2>(static_cast<std::size_t>(cell_count), local_size),
+          sycl::range<2>(1, local_size))),
+      [=](auto idx) {
+        const std::size_t cell = idx.get_global_id(0);
+        const std::size_t local_id = idx.get_local_id(1);
+        const auto npart_cell = k_npart_cell_ptr[cell];
+        std::size_t layer = local_id;
+        while (layer < npart_cell) {
+          k_cell_starts_ptr[cell][layer] =
+              k_cell_starts_parent_ptr[cell][layer];
+          layer += local_size;
+        }
+      });
+
+  created_selection->npart_local = parent_selection.npart_local;
+  created_selection->ncell = cell_count;
+  created_selection->h_npart_cell = h_npart_cell_ptr;
+  created_selection->d_npart_cell = d_npart_cell_ptr;
+  created_selection->d_npart_cell_es = d_npart_cell_es_ptr;
+  created_selection->d_map_cells_to_particles = {k_cell_starts_ptr};
+  e1.wait_and_throw();
 }
 
 } // namespace ParticleSubGroupImplementation

--- a/test/test_copy_selector.cpp
+++ b/test/test_copy_selector.cpp
@@ -4,6 +4,7 @@ TEST(ParticleSubGroup, copy_selector) {
   auto A = subgroup_test_common();
   auto mesh = A->domain->mesh;
   auto sycl_target = A->sycl_target;
+  const int cell_count = mesh->get_cell_count();
 
   auto aa = particle_sub_group(
       A, [=](auto ID) { return ID.at(0) % 3 == 0; },
@@ -19,11 +20,45 @@ TEST(ParticleSubGroup, copy_selector) {
 
   ASSERT_EQ(selection_aa.npart_local, selection_bb.npart_local);
   ASSERT_EQ(selection_aa.ncell, selection_bb.ncell);
-  ASSERT_EQ(selection_aa.h_npart_cell, selection_bb.h_npart_cell);
-  ASSERT_EQ(selection_aa.d_npart_cell, selection_bb.d_npart_cell);
-  ASSERT_EQ(selection_aa.d_npart_cell_es, selection_bb.d_npart_cell_es);
-  ASSERT_EQ(selection_aa.d_map_cells_to_particles.map_ptr,
-            selection_bb.d_map_cells_to_particles.map_ptr);
+
+  for (int cx = 0; cx < cell_count; cx++) {
+    ASSERT_EQ(selection_aa.h_npart_cell[cx], selection_bb.h_npart_cell[cx]);
+  }
+
+  ErrorPropagate ep(sycl_target);
+  auto k_ep = ep.device_ptr();
+
+  auto k_npart_cell_aa = selection_aa.d_npart_cell;
+  auto k_npart_cell_bb = selection_bb.d_npart_cell;
+  auto k_npart_cell_es_aa = selection_aa.d_npart_cell_es;
+  auto k_npart_cell_es_bb = selection_bb.d_npart_cell_es;
+
+  sycl_target->queue
+      .parallel_for(
+          sycl::range<1>(cell_count),
+          [=](auto cx) {
+            NESO_KERNEL_ASSERT(k_npart_cell_aa[cx] == k_npart_cell_bb[cx],
+                               k_ep);
+            NESO_KERNEL_ASSERT(k_npart_cell_es_aa[cx] == k_npart_cell_es_bb[cx],
+                               k_ep);
+          })
+      .wait_and_throw();
+  ASSERT_FALSE(ep.get_flag());
+
+  auto map_aa = get_host_map_cells_to_particles(sycl_target, selection_aa);
+  auto map_bb = get_host_map_cells_to_particles(sycl_target, selection_bb);
+
+  for (int cx = 0; cx < cell_count; cx++) {
+    std::set<INT> set_aa;
+    std::set<INT> set_bb;
+    for (auto ix : map_aa.at(cx)) {
+      set_aa.insert(ix);
+    }
+    for (auto ix : map_bb.at(cx)) {
+      set_bb.insert(ix);
+    }
+    ASSERT_EQ(set_aa, set_bb);
+  }
 
   particle_loop(
       A, [=](auto ID) { ID.at(0) += 3; }, Access::write(Sym<INT>("ID")))
@@ -32,6 +67,50 @@ TEST(ParticleSubGroup, copy_selector) {
   ASSERT_TRUE(bb->create_if_required());
   ASSERT_FALSE(bb->create_if_required());
   ASSERT_FALSE(aa->create_if_required());
+
+  sycl_target->free();
+  mesh->free();
+}
+
+TEST(ParticleSubGroup, copy_selector_static) {
+  auto A = subgroup_test_common();
+  auto mesh = A->domain->mesh;
+  auto sycl_target = A->sycl_target;
+
+  A->add_particle_dat(Sym<INT>("ID2"), 1);
+
+  auto aa = particle_sub_group(
+      A, [=](auto ID) { return ID.at(0) % 2 == 0; },
+      Access::read(Sym<INT>("ID")));
+
+  particle_loop(
+      A, [=](auto ID, auto ID2) { ID2.at(0) = ID.at(0); },
+      Access::read(Sym<INT>("ID")), Access::write(Sym<INT>("ID2")))
+      ->execute();
+
+  auto bb = static_particle_sub_group(aa);
+
+  particle_loop(
+      aa, [=](auto ID) { ID.at(0)--; }, Access::write(Sym<INT>("ID")))
+      ->execute();
+
+  ASSERT_FALSE(bb->create_if_required());
+  ASSERT_TRUE(aa->create_if_required());
+  ASSERT_FALSE(aa->create_if_required());
+
+  ErrorPropagate ep(sycl_target);
+  auto k_ep = ep.device_ptr();
+
+  particle_loop(
+      bb,
+      [=](auto ID, auto ID2) {
+        NESO_KERNEL_ASSERT(ID.at(0) % 2 != 0, k_ep);
+        NESO_KERNEL_ASSERT(ID2.at(0) % 2 == 0, k_ep);
+      },
+      Access::read(Sym<INT>("ID")), Access::read(Sym<INT>("ID2")))
+      ->execute();
+
+  ASSERT_FALSE(ep.get_flag());
 
   sycl_target->free();
   mesh->free();


### PR DESCRIPTION
* Fix CopySelector for when the child is a static sub group.