### PR TITLE
Feature/robust line segment directions

### DIFF
--- a/include/neso_particles/device_functions.hpp
+++ b/include/neso_particles/device_functions.hpp
@@ -87,6 +87,34 @@ template <int N, typename T> inline T dot_product(const T *a, const T *b) {
 } // namespace Kernel
 
 /**
+ * For a line segment [ax, ay] - [bx, by] return ix,iy,jx,jy such that [ix, iy]
+ * - [jx, jy] is the same line segment as [ax, ay] - [bx, by] but the outputs
+ * are independent of the order in which a and b are specified. i.e. the
+ * direction of the output line segment is always in the same direction.
+ *
+ * @param[in] ax First point of line segment, x coordinate.
+ * @param[in] ay First point of line segment, y coordinate.
+ * @param[in] bx Second point of line segment, x coordinate.
+ * @param[in] by Second point of line segment, y coordinate.
+ * @param[in, out] ix First point of output line segment, x coordinate.
+ * @param[in, out] iy First point of output line segment, y coordinate.
+ * @param[in, out] jx Second point of output line segment, x coordinate.
+ * @param[in, out] jy Second point of output line segment, y coordinate.
+ */
+inline void consistent_line_orientation_2d(const REAL ax, const REAL ay,
+                                           const REAL bx, const REAL by,
+                                           REAL *ix, REAL *iy, REAL *jx,
+                                           REAL *jy) {
+  const bool axfirst = ax < bx;
+  const bool ayfirst = ay < by;
+  const bool afirst = ax == bx ? ayfirst : axfirst;
+  *ix = afirst ? ax : bx;
+  *iy = afirst ? ay : by;
+  *jx = afirst ? bx : ax;
+  *jy = afirst ? by : ay;
+}
+
+/**
  * Compute the intersection point parameter (lambda0, lambda1) for the lines
  * [(xa, ya), (xb, yb)] and [(x0, y0), (x1, y1)].
  * Assuming that x1 - x0 != 0 and that the lines are not parallel.

--- a/src/external_interfaces/petsc/dmplex_helper.cpp
+++ b/src/external_interfaces/petsc/dmplex_helper.cpp
@@ -448,10 +448,18 @@ bool DMPlexHelper::cell_contains_point(const PetscInt index,
   }
 
   for (int facex = 0; facex < num_faces; facex++) {
-    REAL xi = vertices[faces[2 * facex + 0] * 2 + 0];
-    REAL yi = vertices[faces[2 * facex + 0] * 2 + 1];
-    REAL xj = vertices[faces[2 * facex + 1] * 2 + 0];
-    REAL yj = vertices[faces[2 * facex + 1] * 2 + 1];
+    const REAL xi_t = vertices[faces[2 * facex + 0] * 2 + 0];
+    const REAL yi_t = vertices[faces[2 * facex + 0] * 2 + 1];
+    const REAL xj_t = vertices[faces[2 * facex + 1] * 2 + 0];
+    const REAL yj_t = vertices[faces[2 * facex + 1] * 2 + 1];
+
+    REAL xi = 0.0;
+    REAL yi = 0.0;
+    REAL xj = 0.0;
+    REAL yj = 0.0;
+
+    consistent_line_orientation_2d(xi_t, yi_t, xj_t, yj_t, &xi, &yi, &xj, &yj);
+
     // Is the point in a corner
     if ((x0 == xj) && (x1 == yj)) {
       num_crossings = 1;

--- a/src/external_interfaces/petsc/particle_cell_mapping/dmplex_2d_mapper.cpp
+++ b/src/external_interfaces/petsc/particle_cell_mapping/dmplex_2d_mapper.cpp
@@ -204,10 +204,18 @@ void DMPlex2DMapper::map(ParticleGroup &particle_group, const int map_cell) {
           const REAL *vertices = cell_data->vertices;
 
           for (int facex = 0; facex < num_vertices; facex++) {
-            REAL xi = vertices[faces[2 * facex + 0] * 2 + 0];
-            REAL yi = vertices[faces[2 * facex + 0] * 2 + 1];
-            REAL xj = vertices[faces[2 * facex + 1] * 2 + 0];
-            REAL yj = vertices[faces[2 * facex + 1] * 2 + 1];
+            const REAL xi_t = vertices[faces[2 * facex + 0] * 2 + 0];
+            const REAL yi_t = vertices[faces[2 * facex + 0] * 2 + 1];
+            const REAL xj_t = vertices[faces[2 * facex + 1] * 2 + 0];
+            const REAL yj_t = vertices[faces[2 * facex + 1] * 2 + 1];
+            REAL xi = 0.0;
+            REAL yi = 0.0;
+            REAL xj = 0.0;
+            REAL yj = 0.0;
+
+            consistent_line_orientation_2d(xi_t, yi_t, xj_t, yj_t, &xi, &yi,
+                                           &xj, &yj);
+
             // Is the point in a corner
             if ((x0 == xj) && (x1 == yj)) {
               num_crossings = 1;

--- a/test/test_device_functions.cpp
+++ b/test/test_device_functions.cpp
@@ -6,6 +6,62 @@
 
 using namespace NESO::Particles;
 
+TEST(DeviceFunctions, consistent_line_orientation_2d) {
+
+  REAL ax, ay, bx, by;
+  REAL ix, iy, jx, jy;
+  {
+    ax = 1.0;
+    ay = 2.0;
+    bx = 3.0;
+    by = 4.0;
+    consistent_line_orientation_2d(ax, ay, bx, by, &ix, &iy, &jx, &jy);
+    ASSERT_EQ(ax, ix);
+    ASSERT_EQ(ay, iy);
+    ASSERT_EQ(bx, jx);
+    ASSERT_EQ(by, jy);
+    consistent_line_orientation_2d(bx, by, ax, ay, &ix, &iy, &jx, &jy);
+    ASSERT_EQ(ax, ix);
+    ASSERT_EQ(ay, iy);
+    ASSERT_EQ(bx, jx);
+    ASSERT_EQ(by, jy);
+  }
+
+  {
+    ax = 1.0;
+    ay = 4.0;
+    bx = 1.0;
+    by = 2.0;
+    consistent_line_orientation_2d(ax, ay, bx, by, &ix, &iy, &jx, &jy);
+    ASSERT_EQ(bx, ix);
+    ASSERT_EQ(by, iy);
+    ASSERT_EQ(ax, jx);
+    ASSERT_EQ(ay, jy);
+    consistent_line_orientation_2d(bx, by, ax, ay, &ix, &iy, &jx, &jy);
+    ASSERT_EQ(bx, ix);
+    ASSERT_EQ(by, iy);
+    ASSERT_EQ(ax, jx);
+    ASSERT_EQ(ay, jy);
+  }
+
+  {
+    ax = 1.0;
+    ay = 2.0;
+    bx = 3.0;
+    by = 2.0;
+    consistent_line_orientation_2d(ax, ay, bx, by, &ix, &iy, &jx, &jy);
+    ASSERT_EQ(ax, ix);
+    ASSERT_EQ(ay, iy);
+    ASSERT_EQ(bx, jx);
+    ASSERT_EQ(by, jy);
+    consistent_line_orientation_2d(bx, by, ax, ay, &ix, &iy, &jx, &jy);
+    ASSERT_EQ(ax, ix);
+    ASSERT_EQ(ay, iy);
+    ASSERT_EQ(bx, jx);
+    ASSERT_EQ(by, jy);
+  }
+}
+
 TEST(DeviceFunctions, line_segment_intersection_inner) {
 
   REAL l0, l1;


### PR DESCRIPTION
* Give edges between DMPlex cells a consistent direction for odd-even cell binning implementations.