### PR TITLE
Pair Masking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ set(SRC_FILES
     ${SRC_DIR}/pair_loop/cellwise_pair_list_simple.cpp
     ${SRC_DIR}/pair_loop/cellwise_pair_list_host.cpp
     ${SRC_DIR}/pair_loop/cellwise_pair_list_block.cpp
+    ${SRC_DIR}/pair_loop/pair_mask.cpp
     ${SRC_DIR}/particle_dat.cpp
     ${SRC_DIR}/particle_group.cpp
     ${SRC_DIR}/particle_set.cpp
@@ -272,6 +273,7 @@ set(HEADER_FILES
     ${INCLUDE_DIR_NESO_PARTICLES}/pair_loop/cellwise_pair_list_block.hpp
     ${INCLUDE_DIR_NESO_PARTICLES}/pair_loop/cellwise_pair_list_host.hpp
     ${INCLUDE_DIR_NESO_PARTICLES}/pair_loop/pair_loop.hpp
+    ${INCLUDE_DIR_NESO_PARTICLES}/pair_loop/pair_mask.hpp
     ${INCLUDE_DIR_NESO_PARTICLES}/pair_loop/particle_pair_loop_args.hpp
     ${INCLUDE_DIR_NESO_PARTICLES}/pair_loop/particle_pair_loop_base.hpp
     ${INCLUDE_DIR_NESO_PARTICLES}/pair_loop/particle_pair_loop_index.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ set(SRC_FILES
     ${SRC_DIR}/containers/ephemeral_dats.cpp
     ${SRC_DIR}/containers/global_array.cpp
     ${SRC_DIR}/containers/local_array.cpp
+    ${SRC_DIR}/containers/mask_array.cpp
     ${SRC_DIR}/containers/particle_set_device.cpp
     ${SRC_DIR}/containers/sym_vector.cpp
     ${SRC_DIR}/containers/sym_vector_pointer_cache.cpp
@@ -191,6 +192,7 @@ set(HEADER_FILES
     ${INCLUDE_DIR_NESO_PARTICLES}/containers/local_memory_interlaced.hpp
     ${INCLUDE_DIR_NESO_PARTICLES}/containers/lookup_table.hpp
     ${INCLUDE_DIR_NESO_PARTICLES}/containers/nd_local_array.hpp
+    ${INCLUDE_DIR_NESO_PARTICLES}/containers/mask_array.hpp
     ${INCLUDE_DIR_NESO_PARTICLES}/containers/particle_set_device.hpp
     ${INCLUDE_DIR_NESO_PARTICLES}/containers/product_matrix.hpp
     ${INCLUDE_DIR_NESO_PARTICLES}/containers/resource_stack.hpp

--- a/include/neso_particles.hpp
+++ b/include/neso_particles.hpp
@@ -20,6 +20,7 @@
 #include "neso_particles/containers/global_array.hpp"
 #include "neso_particles/containers/local_array.hpp"
 #include "neso_particles/containers/lookup_table.hpp"
+#include "neso_particles/containers/mask_array.hpp"
 #include "neso_particles/containers/nd_index.hpp"
 #include "neso_particles/containers/nd_local_array.hpp"
 #include "neso_particles/containers/product_matrix.hpp"

--- a/include/neso_particles/algorithms/dsmc/pair_sampler_no_replacement.hpp
+++ b/include/neso_particles/algorithms/dsmc/pair_sampler_no_replacement.hpp
@@ -35,6 +35,8 @@ protected:
 
   std::unique_ptr<BufferDevice<INT>> d_max_pair_count;
 
+  MaskArraySharedPtr mask_array;
+
 public:
   /// Disable (implicit) copies.
   PairSamplerNoReplacement(const PairSamplerNoReplacement &st) = delete;
@@ -97,6 +99,12 @@ public:
    * @returns The number of pairs in the pair list.
    */
   virtual INT get_num_pairs() override;
+
+  /**
+   * @returns The MaskArray which can be used to mask off pairs. By default all
+   * pairs will be enabled.
+   */
+  virtual MaskArraySharedPtr get_mask_array() override;
 };
 
 } // namespace NESO::Particles::DSMC

--- a/include/neso_particles/algorithms/dsmc/pair_sampler_no_replacement.hpp
+++ b/include/neso_particles/algorithms/dsmc/pair_sampler_no_replacement.hpp
@@ -35,7 +35,7 @@ protected:
 
   std::unique_ptr<BufferDevice<INT>> d_max_pair_count;
 
-  MaskArraySharedPtr mask_array;
+  PairMaskSharedPtr pair_mask;
 
 public:
   /// Disable (implicit) copies.
@@ -101,10 +101,10 @@ public:
   virtual INT get_num_pairs() override;
 
   /**
-   * @returns The MaskArray which can be used to mask off pairs. By default all
+   * @returns The PairMask which can be used to mask off pairs. By default all
    * pairs will be enabled.
    */
-  virtual MaskArraySharedPtr get_mask_array() override;
+  virtual PairMaskSharedPtr get_pair_mask() override;
 };
 
 } // namespace NESO::Particles::DSMC

--- a/include/neso_particles/containers/mask_array.hpp
+++ b/include/neso_particles/containers/mask_array.hpp
@@ -196,6 +196,34 @@ create_kernel_arg([[maybe_unused]] ParticleLoopIteration &iterationx,
 
 } // namespace ParticleLoopImplementation
 
+namespace ParticlePairLoopImplementation {
+
+/**
+ *  Function to create the kernel argument for MaskArray read
+ * access in a pair loop.
+ */
+inline void create_kernel_arg(
+    [[maybe_unused]] ParticlePairLoopIteration &iteration,
+    [[maybe_unused]] ParticleLoopImplementation::ParticleLoopIteration
+        &iteration_particle,
+    Access::MaskArray::Read &rhs, Access::MaskArray::Read &lhs) {
+  lhs = rhs;
+}
+
+/**
+ * Function to create the kernel argument for MaskArray write
+ * access in a pair loop.
+ */
+inline void create_kernel_arg(
+    [[maybe_unused]] ParticlePairLoopIteration &iteration,
+    [[maybe_unused]] ParticleLoopImplementation::ParticleLoopIteration
+        &iteration_particle,
+    Access::MaskArray::Write &rhs, Access::MaskArray::Write &lhs) {
+  lhs = rhs;
+}
+
+} // namespace ParticlePairLoopImplementation
+
 /**
  * Type that stores N bits per entry (particle).
  */

--- a/include/neso_particles/containers/mask_array.hpp
+++ b/include/neso_particles/containers/mask_array.hpp
@@ -281,6 +281,12 @@ public:
    * @returns Access to the masks via the device type.
    */
   MaskArrayDevice get_device();
+
+  /**
+   * @param mask_index Index of mask in entry to count, default 0.
+   * @returns Number of masks set to true.
+   */
+  std::size_t get_num_masks_true(const std::size_t mask_index = 0);
 };
 
 namespace ParticleLoopImplementation {

--- a/include/neso_particles/containers/mask_array.hpp
+++ b/include/neso_particles/containers/mask_array.hpp
@@ -27,7 +27,7 @@ template <typename T> struct MaskArrayDeviceBase {
 
   T d_masks{nullptr};
   std::size_t num_masks_per_entry{0};
-  std::size_t stride{0};
+  std::size_t size{0};
 
   /**
    * @param index_entry Index of the entry in [0, size)·
@@ -37,9 +37,9 @@ template <typename T> struct MaskArrayDeviceBase {
    * the provided entry and bit.
    */
   static inline MaskArrayBaseType
-  get_inner_index(const std::size_t index_entry,
-                  [[maybe_unused]] const std::size_t index_bit) {
-    return index_entry % num_bits_per_base;
+  get_inner_index([[maybe_unused]] const std::size_t index_entry,
+                  const std::size_t index_bit) {
+    return index_bit % num_bits_per_base;
   }
 
   /**
@@ -49,9 +49,9 @@ template <typename T> struct MaskArrayDeviceBase {
    * @returns The index to a MaskArrayBaseType.
    */
   static inline MaskArrayBaseType
-  get_outer_index(const std::size_t index_entry,
-                  [[maybe_unused]] const std::size_t index_bit) {
-    return index_entry / num_bits_per_base;
+  get_outer_index([[maybe_unused]] const std::size_t index_entry,
+                  const std::size_t index_bit) {
+    return index_bit / num_bits_per_base;
   }
 
   /**
@@ -77,12 +77,12 @@ template <typename T> struct MaskArrayDeviceBase {
    * num_masks_per_entry).
    * @returns Offset to the MaskArrayBaseType containing the mask.
    */
-  inline MaskArrayBaseType
-  get_base_index(const std::size_t index_entry,
-                 [[maybe_unused]] const std::size_t index_bit) const {
-    const std::size_t offset_bit = index_bit * this->stride;
-    const std::size_t offset_entry = get_outer_index(index_entry, index_bit);
-    return offset_bit + offset_entry;
+  inline MaskArrayBaseType get_base_index(const std::size_t index_entry,
+                                          const std::size_t index_bit) const {
+
+    const std::size_t offset_bit =
+        get_outer_index(index_entry, index_bit) * this->size;
+    return offset_bit + index_entry;
   }
 
   /**
@@ -95,8 +95,7 @@ template <typename T> struct MaskArrayDeviceBase {
    */
   inline bool get(const std::size_t index_entry,
                   const std::size_t index_bit) const {
-    auto d_base =
-        this->d_masks + this->get_base_index(index_entry, index_bit);
+    auto d_base = this->d_masks + this->get_base_index(index_entry, index_bit);
     return get_inner(d_base, get_inner_index(index_entry, index_bit));
   }
 };
@@ -136,8 +135,7 @@ struct Write : public MaskArrayDeviceBase<MaskArrayBaseType * RESTRICT> {
    */
   inline void set(const std::size_t index_entry, const std::size_t index_bit,
                   const bool value) const {
-    auto d_base =
-        this->d_masks + this->get_base_index(index_entry, index_bit);
+    auto d_base = this->d_masks + this->get_base_index(index_entry, index_bit);
     set_inner(d_base, get_inner_index(index_entry, index_bit), value);
   }
 };
@@ -216,13 +214,6 @@ public:
   static constexpr MaskArrayBaseType num_bits_per_base =
       sizeof(MaskArrayBaseType) * CHAR_BIT;
 
-  /**
-   * @param N Number of elements.
-   * @returns The number of MaskArrayBaseTypes required for a given number of
-   * elements for one bit (mask) per element.
-   */
-  static std::size_t get_stride(const std::size_t N);
-
   MaskArray() = default;
   ~MaskArray();
 
@@ -232,11 +223,11 @@ public:
   // Number of masks per entry.
   std::size_t num_masks_per_entry{0};
 
+  // Number of base elements per entry.
+  std::size_t num_base_elements_per_entry{0};
+
   // Number of entries.
   std::size_t size{0};
-
-  // Number of base elements required per bit stored per entry.
-  std::size_t stride{0};
 
   /**
    * Create a mask array on a given compute device with a set number of bits per
@@ -273,7 +264,7 @@ create_loop_arg([[maybe_unused]] ParticleLoopGlobalInfo *global_info,
                 [[maybe_unused]] sycl::handler &cgh,
                 Access::Read<MaskArray *> &a) {
   auto tmp = a.obj->get_device();
-  return {tmp.d_masks, tmp.num_masks_per_entry, tmp.stride};
+  return {tmp.d_masks, tmp.num_masks_per_entry, tmp.size};
 }
 
 /**
@@ -284,7 +275,7 @@ create_loop_arg([[maybe_unused]] ParticleLoopGlobalInfo *global_info,
                 [[maybe_unused]] sycl::handler &cgh,
                 Access::Write<MaskArray *> &a) {
   auto tmp = a.obj->get_device();
-  return {tmp.d_masks, tmp.num_masks_per_entry, tmp.stride};
+  return {tmp.d_masks, tmp.num_masks_per_entry, tmp.size};
 }
 
 } // namespace ParticleLoopImplementation

--- a/include/neso_particles/containers/mask_array.hpp
+++ b/include/neso_particles/containers/mask_array.hpp
@@ -25,7 +25,7 @@ struct MaskArrayDevice {
 
   MaskArrayBaseType *RESTRICT d_masks{nullptr};
   std::size_t num_masks_per_entry{0};
-  std::size_t size{0};
+  std::size_t stride{0};
 
   /**
    * @param index_entry Index of the entry in [0, size)·
@@ -61,7 +61,7 @@ struct MaskArrayDevice {
   inline MaskArrayBaseType
   get_base_index(const std::size_t index_entry,
                  [[maybe_unused]] const std::size_t index_bit) const {
-    const std::size_t offset_bit = index_bit * this->size;
+    const std::size_t offset_bit = index_bit * this->stride;
     const std::size_t offset_entry = get_outer_index(index_entry, index_bit);
     return offset_bit + offset_entry;
   }
@@ -115,7 +115,7 @@ struct MaskArrayDevice {
                   const bool value) const {
     MaskArrayBaseType *d_base =
         this->d_masks + this->get_base_index(index_entry, index_bit);
-    set_inner(d_base, index_bit, value);
+    set_inner(d_base, get_inner_index(index_entry, index_bit), value);
   }
 
   /**
@@ -130,7 +130,7 @@ struct MaskArrayDevice {
                   const std::size_t index_bit) const {
     MaskArrayBaseType *d_base =
         this->d_masks + this->get_base_index(index_entry, index_bit);
-    return get_inner(d_base, index_bit);
+    return get_inner(d_base, get_inner_index(index_entry, index_bit));
   }
 };
 
@@ -155,13 +155,10 @@ public:
 
   /**
    * @param N Number of elements.
-   * @param num_masks_per_entry Number of bits per element.
    * @returns The number of MaskArrayBaseTypes required for a given number of
-   * elements and bits (masks) per element.
+   * elements for one bit (mask) per element.
    */
-  static std::size_t
-  get_num_base_elements(const std::size_t N,
-                        const std::size_t num_masks_per_entry);
+  static std::size_t get_stride(const std::size_t N);
 
   MaskArray() = default;
   ~MaskArray();
@@ -174,6 +171,9 @@ public:
 
   // Number of entries.
   std::size_t size{0};
+
+  // Number of base elements required per bit stored per entry.
+  std::size_t stride{0};
 
   /**
    * Create a mask array on a given compute device with a set number of bits per

--- a/include/neso_particles/containers/mask_array.hpp
+++ b/include/neso_particles/containers/mask_array.hpp
@@ -15,7 +15,7 @@ namespace NESO::Particles {
 class MaskArray;
 
 // The base integer type in which the masks are stored.
-using MaskArrayBaseType = std::uint32_t;
+using MaskArrayBaseType = std::uint8_t;
 
 /**
  * Device type for MaskArray.
@@ -48,7 +48,7 @@ template <typename T> struct MaskArrayDeviceBase {
    * num_masks_per_entry).
    * @returns The index to a MaskArrayBaseType.
    */
-  static inline MaskArrayBaseType
+  static inline std::size_t
   get_outer_index([[maybe_unused]] const std::size_t index_entry,
                   const std::size_t index_bit) {
     return index_bit / num_bits_per_base;
@@ -64,6 +64,7 @@ template <typename T> struct MaskArrayDeviceBase {
    */
   static inline bool get_inner(MaskArrayBaseType const *const base,
                                const std::size_t index_bit) {
+
     const MaskArrayBaseType one_at_index = static_cast<MaskArrayBaseType>(1)
                                            << index_bit;
     const MaskArrayBaseType initial_base = *base;
@@ -77,8 +78,8 @@ template <typename T> struct MaskArrayDeviceBase {
    * num_masks_per_entry).
    * @returns Offset to the MaskArrayBaseType containing the mask.
    */
-  inline MaskArrayBaseType get_base_index(const std::size_t index_entry,
-                                          const std::size_t index_bit) const {
+  inline std::size_t get_base_index(const std::size_t index_entry,
+                                    const std::size_t index_bit) const {
 
     const std::size_t offset_bit =
         get_outer_index(index_entry, index_bit) * this->size;

--- a/include/neso_particles/containers/mask_array.hpp
+++ b/include/neso_particles/containers/mask_array.hpp
@@ -18,12 +18,12 @@ using MaskArrayBaseType = std::uint32_t;
 /**
  * Device type for MaskArray.
  */
-struct MaskArrayDevice {
+template <typename T> struct MaskArrayDeviceBase {
   // Number of bits per base element on the device.
   static constexpr MaskArrayBaseType num_bits_per_base =
       sizeof(MaskArrayBaseType) * CHAR_BIT;
 
-  MaskArrayBaseType *RESTRICT d_masks{nullptr};
+  T d_masks{nullptr};
   std::size_t num_masks_per_entry{0};
   std::size_t stride{0};
 
@@ -53,6 +53,23 @@ struct MaskArrayDevice {
   }
 
   /**
+   * Get mask at location in base type.
+   *
+   * @param base Pointer to a base type instance·
+   * @param index_bit Index of the mask (bit) in the entry in [0,
+   * num_masks_per_entry).
+   * @returns Value of mask (bit) at location.
+   */
+  static inline bool get_inner(MaskArrayBaseType const *const base,
+                               const std::size_t index_bit) {
+    const MaskArrayBaseType one_at_index = static_cast<MaskArrayBaseType>(1)
+                                           << index_bit;
+    const MaskArrayBaseType initial_base = *base;
+    const MaskArrayBaseType masked_entry = initial_base & one_at_index;
+    return masked_entry != 0;
+  }
+
+  /**
    * @param index_entry Index of the entry in [0, size)·
    * @param index_bit Index of the mask (bit) in the entry in [0,
    * num_masks_per_entry).
@@ -65,6 +82,27 @@ struct MaskArrayDevice {
     const std::size_t offset_entry = get_outer_index(index_entry, index_bit);
     return offset_bit + offset_entry;
   }
+
+  /**
+   * Get mask at location.
+   *
+   * @param index_entry Index of the entry in [0, size)·
+   * @param index_bit Index of the mask (bit) in the entry in [0,
+   * num_masks_per_entry).
+   * @returns Value of mask (bit) at location.
+   */
+  inline bool get(const std::size_t index_entry,
+                  const std::size_t index_bit) const {
+    MaskArrayBaseType *d_base =
+        this->d_masks + this->get_base_index(index_entry, index_bit);
+    return get_inner(d_base, get_inner_index(index_entry, index_bit));
+  }
+};
+
+namespace Access::MaskArray {
+using Read = MaskArrayDeviceBase<MaskArrayBaseType const * RESTRICT>;
+
+struct Write : public MaskArrayDeviceBase<MaskArrayBaseType * RESTRICT> {
 
   /**
    * Set mask at location in base type.
@@ -87,23 +125,6 @@ struct MaskArrayDevice {
   }
 
   /**
-   * Get mask at location in base type.
-   *
-   * @param base Pointer to a base type instance·
-   * @param index_bit Index of the mask (bit) in the entry in [0,
-   * num_masks_per_entry).
-   * @returns Value of mask (bit) at location.
-   */
-  static inline bool get_inner(MaskArrayBaseType const *const base,
-                               const std::size_t index_bit) {
-    const MaskArrayBaseType one_at_index = static_cast<MaskArrayBaseType>(1)
-                                           << index_bit;
-    const MaskArrayBaseType initial_base = *base;
-    const MaskArrayBaseType masked_entry = initial_base & one_at_index;
-    return masked_entry != 0;
-  }
-
-  /**
    * Set mask at location.
    *
    * @param index_entry Index of the entry in [0, size)·
@@ -117,22 +138,11 @@ struct MaskArrayDevice {
         this->d_masks + this->get_base_index(index_entry, index_bit);
     set_inner(d_base, get_inner_index(index_entry, index_bit), value);
   }
-
-  /**
-   * Get mask at location.
-   *
-   * @param index_entry Index of the entry in [0, size)·
-   * @param index_bit Index of the mask (bit) in the entry in [0,
-   * num_masks_per_entry).
-   * @returns Value of mask (bit) at location.
-   */
-  inline bool get(const std::size_t index_entry,
-                  const std::size_t index_bit) const {
-    MaskArrayBaseType *d_base =
-        this->d_masks + this->get_base_index(index_entry, index_bit);
-    return get_inner(d_base, get_inner_index(index_entry, index_bit));
-  }
 };
+
+} // namespace Access::MaskArray
+
+using MaskArrayDevice = Access::MaskArray::Write;
 
 /**
  * Type that stores N bits per entry (particle).

--- a/include/neso_particles/containers/mask_array.hpp
+++ b/include/neso_particles/containers/mask_array.hpp
@@ -244,7 +244,7 @@ public:
       sizeof(MaskArrayBaseType) * CHAR_BIT;
 
   MaskArray() = default;
-  ~MaskArray();
+  virtual ~MaskArray();
 
   // Compute device.
   SYCLTargetSharedPtr sycl_target;
@@ -305,7 +305,7 @@ create_loop_arg([[maybe_unused]] ParticleLoopGlobalInfo *global_info,
 }
 
 /**
- * Method to compute access to a MaskArray (read)
+ * Method to compute access to a MaskArray (write)
  */
 inline Access::MaskArray::Write
 create_loop_arg([[maybe_unused]] ParticleLoopGlobalInfo *global_info,

--- a/include/neso_particles/containers/mask_array.hpp
+++ b/include/neso_particles/containers/mask_array.hpp
@@ -102,9 +102,9 @@ template <typename T> struct MaskArrayDeviceBase {
 };
 
 namespace Access::MaskArray {
-using Read = MaskArrayDeviceBase<MaskArrayBaseType const * RESTRICT>;
+using Read = MaskArrayDeviceBase<MaskArrayBaseType const *>;
 
-struct Write : public MaskArrayDeviceBase<MaskArrayBaseType * RESTRICT> {
+struct Write : public MaskArrayDeviceBase<MaskArrayBaseType *> {
 
   /**
    * Set mask at location in base type.
@@ -288,6 +288,8 @@ public:
    */
   std::size_t get_num_masks_true(const std::size_t mask_index = 0);
 };
+
+using MaskArraySharedPtr = std::shared_ptr<MaskArray>;
 
 namespace ParticleLoopImplementation {
 

--- a/include/neso_particles/containers/mask_array.hpp
+++ b/include/neso_particles/containers/mask_array.hpp
@@ -296,24 +296,18 @@ namespace ParticleLoopImplementation {
 /**
  * Method to compute access to a MaskArray (read)
  */
-inline Access::MaskArray::Read
+Access::MaskArray::Read
 create_loop_arg([[maybe_unused]] ParticleLoopGlobalInfo *global_info,
                 [[maybe_unused]] sycl::handler &cgh,
-                Access::Read<MaskArray *> &a) {
-  auto tmp = a.obj->get_device();
-  return {tmp.d_masks, tmp.num_masks_per_entry, tmp.size};
-}
+                Access::Read<MaskArray *> &a);
 
 /**
  * Method to compute access to a MaskArray (write)
  */
-inline Access::MaskArray::Write
+Access::MaskArray::Write
 create_loop_arg([[maybe_unused]] ParticleLoopGlobalInfo *global_info,
                 [[maybe_unused]] sycl::handler &cgh,
-                Access::Write<MaskArray *> &a) {
-  auto tmp = a.obj->get_device();
-  return {tmp.d_masks, tmp.num_masks_per_entry, tmp.size};
-}
+                Access::Write<MaskArray *> &a);
 
 } // namespace ParticleLoopImplementation
 

--- a/include/neso_particles/containers/mask_array.hpp
+++ b/include/neso_particles/containers/mask_array.hpp
@@ -12,6 +12,8 @@
 
 namespace NESO::Particles {
 
+class MaskArray;
+
 // The base integer type in which the masks are stored.
 using MaskArrayBaseType = std::uint32_t;
 
@@ -93,7 +95,7 @@ template <typename T> struct MaskArrayDeviceBase {
    */
   inline bool get(const std::size_t index_entry,
                   const std::size_t index_bit) const {
-    MaskArrayBaseType *d_base =
+    auto d_base =
         this->d_masks + this->get_base_index(index_entry, index_bit);
     return get_inner(d_base, get_inner_index(index_entry, index_bit));
   }
@@ -134,7 +136,7 @@ struct Write : public MaskArrayDeviceBase<MaskArrayBaseType * RESTRICT> {
    */
   inline void set(const std::size_t index_entry, const std::size_t index_bit,
                   const bool value) const {
-    MaskArrayBaseType *d_base =
+    auto d_base =
         this->d_masks + this->get_base_index(index_entry, index_bit);
     set_inner(d_base, get_inner_index(index_entry, index_bit), value);
   }
@@ -143,6 +145,57 @@ struct Write : public MaskArrayDeviceBase<MaskArrayBaseType * RESTRICT> {
 } // namespace Access::MaskArray
 
 using MaskArrayDevice = Access::MaskArray::Write;
+
+namespace ParticleLoopImplementation {
+
+/**
+ *  Loop parameter for read access of a MaskArray.
+ */
+template <> struct LoopParameter<Access::Read<MaskArray>> {
+  using type = Access::MaskArray::Read;
+};
+
+/**
+ *  Loop parameter for write access of a MaskArray.
+ */
+template <> struct LoopParameter<Access::Write<MaskArray>> {
+  using type = Access::MaskArray::Write;
+};
+
+/**
+ *  KernelParameter type for read access to a MaskArray.
+ */
+template <> struct KernelParameter<Access::Read<MaskArray>> {
+  using type = Access::MaskArray::Read;
+};
+
+/**
+ *  KernelParameter type for write access to a MaskArray.
+ */
+template <> struct KernelParameter<Access::Write<MaskArray>> {
+  using type = Access::MaskArray::Write;
+};
+
+/**
+ *  Function to create the kernel argument for MaskArray read access.
+ */
+inline void
+create_kernel_arg([[maybe_unused]] ParticleLoopIteration &iterationx,
+                  Access::MaskArray::Read &rhs, Access::MaskArray::Read &lhs) {
+  lhs = rhs;
+}
+
+/**
+ *  Function to create the kernel argument for MaskArray write access.
+ */
+inline void
+create_kernel_arg([[maybe_unused]] ParticleLoopIteration &iterationx,
+                  Access::MaskArray::Write &rhs,
+                  Access::MaskArray::Write &lhs) {
+  lhs = rhs;
+}
+
+} // namespace ParticleLoopImplementation
 
 /**
  * Type that stores N bits per entry (particle).
@@ -209,6 +262,32 @@ public:
    */
   MaskArrayDevice get_device();
 };
+
+namespace ParticleLoopImplementation {
+
+/**
+ * Method to compute access to a MaskArray (read)
+ */
+inline Access::MaskArray::Read
+create_loop_arg([[maybe_unused]] ParticleLoopGlobalInfo *global_info,
+                [[maybe_unused]] sycl::handler &cgh,
+                Access::Read<MaskArray *> &a) {
+  auto tmp = a.obj->get_device();
+  return {tmp.d_masks, tmp.num_masks_per_entry, tmp.stride};
+}
+
+/**
+ * Method to compute access to a MaskArray (read)
+ */
+inline Access::MaskArray::Write
+create_loop_arg([[maybe_unused]] ParticleLoopGlobalInfo *global_info,
+                [[maybe_unused]] sycl::handler &cgh,
+                Access::Write<MaskArray *> &a) {
+  auto tmp = a.obj->get_device();
+  return {tmp.d_masks, tmp.num_masks_per_entry, tmp.stride};
+}
+
+} // namespace ParticleLoopImplementation
 
 } // namespace NESO::Particles
 

--- a/include/neso_particles/containers/mask_array.hpp
+++ b/include/neso_particles/containers/mask_array.hpp
@@ -1,0 +1,124 @@
+#ifndef _NESO_PARTICLES_MASK_ARRAY_HPP_
+#define _NESO_PARTICLES_MASK_ARRAY_HPP_
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+
+#include "../compute_target.hpp"
+#include "../device_buffers.hpp"
+#include "../loop/particle_loop_base.hpp"
+#include "../pair_loop/particle_pair_loop_base.hpp"
+
+namespace NESO::Particles {
+
+// The base integer type in which the masks are stored.
+using MaskArrayBaseType = std::uint32_t;
+
+/**
+ * Device type for MaskArray.
+ */
+struct MaskArrayDevice {
+  // Number of bits per base element on the device.
+  static constexpr MaskArrayBaseType num_bits_per_base =
+      sizeof(MaskArrayBaseType) * CHAR_BIT;
+
+  MaskArrayBaseType const *d_masks{nullptr};
+  std::size_t num_masks_per_entry{0};
+  std::size_t size{0};
+
+  /**
+   * @param index_entry Index of the entry in [0, size)·
+   * @param index_bit Index of the mask (bit) in the entry in [0,
+   * num_masks_per_entry).
+   * @returns The entry within a single MaskArrayBaseType that corresponds to
+   * the provided entry and bit.
+   */
+  static inline MaskArrayBaseType
+  get_inner_index(const std::size_t index_entry,
+                  [[maybe_unused]] const std::size_t index_bit) {
+    return index_entry % num_bits_per_base;
+  }
+
+  /**
+   * @param index_entry Index of the entry in [0, size)·
+   * @param index_bit Index of the mask (bit) in the entry in [0,
+   * num_masks_per_entry).
+   * @returns The index to a MaskArrayBaseType.
+   */
+  static inline MaskArrayBaseType
+  get_outer_index(const std::size_t index_entry,
+                  [[maybe_unused]] const std::size_t index_bit) {
+    return index_entry / num_bits_per_base;
+  }
+};
+
+/**
+ * Type that stores N bits per entry (particle).
+ */
+class MaskArray {
+protected:
+  std::shared_ptr<BufferDevice<MaskArrayBaseType>> d_masks;
+  sycl::event event;
+
+public:
+  /**
+   * @param value Mask value to set all masks to.
+   * @returns A base element that is either all 1 or 0.
+   */
+  static MaskArrayBaseType get_reset_mask(const bool value);
+
+  // Number of bits per base element on the device.
+  static constexpr MaskArrayBaseType num_bits_per_base =
+      sizeof(MaskArrayBaseType) * CHAR_BIT;
+
+  /**
+   * @param N Number of elements.
+   * @param num_masks_per_entry Number of bits per element.
+   * @returns The number of MaskArrayBaseTypes required for a given number of
+   * elements and bits (masks) per element.
+   */
+  static std::size_t
+  get_num_base_elements(const std::size_t N,
+                        const std::size_t num_masks_per_entry);
+
+  MaskArray() = default;
+  ~MaskArray();
+
+  // Compute device.
+  SYCLTargetSharedPtr sycl_target;
+
+  // Number of masks per entry.
+  std::size_t num_masks_per_entry{0};
+
+  // Number of entries.
+  std::size_t size{0};
+
+  /**
+   * Create a mask array on a given compute device with a set number of bits per
+   * entry.
+   *
+   * @param sycl_target Compute device.
+   * @param num_masks_per_entry Number of bits stored per entry.
+   */
+  MaskArray(SYCLTargetSharedPtr sycl_target,
+            const std::size_t num_masks_per_entry);
+
+  /**
+   * Zero the masks optionally provide a new array size.
+   *
+   * @param reset_value Provide the mask value to reset all entries to.
+   * @param new_size Optional new array size.
+   */
+  void reset(const bool value,
+             std::optional<std::size_t> new_size = std::nullopt);
+
+  /**
+   * @returns Access to the masks via the device type.
+   */
+  MaskArrayDevice get_device();
+};
+
+} // namespace NESO::Particles
+
+#endif

--- a/include/neso_particles/containers/mask_array.hpp
+++ b/include/neso_particles/containers/mask_array.hpp
@@ -23,7 +23,7 @@ struct MaskArrayDevice {
   static constexpr MaskArrayBaseType num_bits_per_base =
       sizeof(MaskArrayBaseType) * CHAR_BIT;
 
-  MaskArrayBaseType const *d_masks{nullptr};
+  MaskArrayBaseType *RESTRICT d_masks{nullptr};
   std::size_t num_masks_per_entry{0};
   std::size_t size{0};
 
@@ -50,6 +50,87 @@ struct MaskArrayDevice {
   get_outer_index(const std::size_t index_entry,
                   [[maybe_unused]] const std::size_t index_bit) {
     return index_entry / num_bits_per_base;
+  }
+
+  /**
+   * @param index_entry Index of the entry in [0, size)·
+   * @param index_bit Index of the mask (bit) in the entry in [0,
+   * num_masks_per_entry).
+   * @returns Offset to the MaskArrayBaseType containing the mask.
+   */
+  inline MaskArrayBaseType
+  get_base_index(const std::size_t index_entry,
+                 [[maybe_unused]] const std::size_t index_bit) const {
+    const std::size_t offset_bit = index_bit * this->size;
+    const std::size_t offset_entry = get_outer_index(index_entry, index_bit);
+    return offset_bit + offset_entry;
+  }
+
+  /**
+   * Set mask at location in base type.
+   *
+   * @param base Pointer to a base type instance·
+   * @param index_bit Index of the mask (bit) in the entry in [0,
+   * num_masks_per_entry).
+   * @param value Value of mask (bit) to set.
+   */
+  static inline void set_inner(MaskArrayBaseType *base,
+                               const std::size_t index_bit, const bool value) {
+
+    const MaskArrayBaseType one_at_index = static_cast<MaskArrayBaseType>(1)
+                                           << index_bit;
+
+    const MaskArrayBaseType initial_base = *base;
+    const MaskArrayBaseType set_true = one_at_index | initial_base;
+    const MaskArrayBaseType set_false = (~one_at_index) & initial_base;
+    *base = value ? set_true : set_false;
+  }
+
+  /**
+   * Get mask at location in base type.
+   *
+   * @param base Pointer to a base type instance·
+   * @param index_bit Index of the mask (bit) in the entry in [0,
+   * num_masks_per_entry).
+   * @returns Value of mask (bit) at location.
+   */
+  static inline bool get_inner(MaskArrayBaseType const *const base,
+                               const std::size_t index_bit) {
+    const MaskArrayBaseType one_at_index = static_cast<MaskArrayBaseType>(1)
+                                           << index_bit;
+    const MaskArrayBaseType initial_base = *base;
+    const MaskArrayBaseType masked_entry = initial_base & one_at_index;
+    return masked_entry != 0;
+  }
+
+  /**
+   * Set mask at location.
+   *
+   * @param index_entry Index of the entry in [0, size)·
+   * @param index_bit Index of the mask (bit) in the entry in [0,
+   * num_masks_per_entry).
+   * @param value Value of mask (bit) to set.
+   */
+  inline void set(const std::size_t index_entry, const std::size_t index_bit,
+                  const bool value) const {
+    MaskArrayBaseType *d_base =
+        this->d_masks + this->get_base_index(index_entry, index_bit);
+    set_inner(d_base, index_bit, value);
+  }
+
+  /**
+   * Get mask at location.
+   *
+   * @param index_entry Index of the entry in [0, size)·
+   * @param index_bit Index of the mask (bit) in the entry in [0,
+   * num_masks_per_entry).
+   * @returns Value of mask (bit) at location.
+   */
+  inline bool get(const std::size_t index_entry,
+                  const std::size_t index_bit) const {
+    MaskArrayBaseType *d_base =
+        this->d_masks + this->get_base_index(index_entry, index_bit);
+    return get_inner(d_base, index_bit);
   }
 };
 

--- a/include/neso_particles/loop/particle_loop_args.hpp
+++ b/include/neso_particles/loop/particle_loop_args.hpp
@@ -15,6 +15,7 @@
 #include "../containers/local_array.hpp"
 #include "../containers/local_memory_block.hpp"
 #include "../containers/local_memory_interlaced.hpp"
+#include "../containers/mask_array.hpp"
 #include "../containers/nd_local_array.hpp"
 #include "../containers/particle_set_device.hpp"
 #include "../containers/product_matrix.hpp"

--- a/include/neso_particles/pair_loop/cellwise_pair_list.hpp
+++ b/include/neso_particles/pair_loop/cellwise_pair_list.hpp
@@ -3,9 +3,9 @@
 
 #include "../compute_target.hpp"
 #include "../containers/cell_dat.hpp"
-#include "../containers/mask_array.hpp"
 #include "../device_buffers.hpp"
 #include "cellwise_pair_list_host.hpp"
+#include "pair_mask.hpp"
 
 #include <map>
 #include <vector>
@@ -135,10 +135,10 @@ public:
   virtual bool validate_pair_list(SYCLTargetSharedPtr sycl_target);
 
   /**
-   * @returns The MaskArray which can be used to mask off pairs. By default all
+   * @returns The PairMask which can be used to mask off pairs. By default all
    * pairs will be enabled.
    */
-  virtual MaskArraySharedPtr get_mask_array() = 0;
+  virtual PairMaskSharedPtr get_pair_mask() = 0;
 };
 
 using CellwisePairListSharedPtr = std::shared_ptr<CellwisePairList>;

--- a/include/neso_particles/pair_loop/cellwise_pair_list.hpp
+++ b/include/neso_particles/pair_loop/cellwise_pair_list.hpp
@@ -3,6 +3,7 @@
 
 #include "../compute_target.hpp"
 #include "../containers/cell_dat.hpp"
+#include "../containers/mask_array.hpp"
 #include "../device_buffers.hpp"
 #include "cellwise_pair_list_host.hpp"
 
@@ -30,6 +31,9 @@ struct CellwisePairListDevice {
   int max_pair_count{0};
   int max_wave_count{0};
   INT pair_count{0};
+
+  // The masks for the pairs.
+  MaskArrayDevice mask_array;
 
   /**
    * @param cell Cell to retrieve number of waves for.
@@ -129,6 +133,12 @@ public:
    * malformed.
    */
   virtual bool validate_pair_list(SYCLTargetSharedPtr sycl_target);
+
+  /**
+   * @returns The MaskArray which can be used to mask off pairs. By default all
+   * pairs will be enabled.
+   */
+  virtual MaskArraySharedPtr get_mask_array() = 0;
 };
 
 using CellwisePairListSharedPtr = std::shared_ptr<CellwisePairList>;

--- a/include/neso_particles/pair_loop/cellwise_pair_list_simple.hpp
+++ b/include/neso_particles/pair_loop/cellwise_pair_list_simple.hpp
@@ -35,7 +35,7 @@ protected:
 
   int mode{0};
 
-  MaskArraySharedPtr mask_array;
+  PairMaskSharedPtr pair_mask;
 
 public:
   /// Compute device holding pairs.
@@ -102,7 +102,7 @@ public:
    * @returns The MaskArray which can be used to mask off pairs. By default all
    * pairs will be enabled.
    */
-  virtual MaskArraySharedPtr get_mask_array() override;
+  virtual PairMaskSharedPtr get_pair_mask() override;
 };
 
 using CellwisePairListSimpleSharedPtr = std::shared_ptr<CellwisePairListSimple>;

--- a/include/neso_particles/pair_loop/cellwise_pair_list_simple.hpp
+++ b/include/neso_particles/pair_loop/cellwise_pair_list_simple.hpp
@@ -35,6 +35,8 @@ protected:
 
   int mode{0};
 
+  MaskArraySharedPtr mask_array;
+
 public:
   /// Compute device holding pairs.
   SYCLTargetSharedPtr sycl_target;
@@ -95,6 +97,12 @@ public:
    * @returns The number of pairs in the pair list.
    */
   virtual INT get_num_pairs() override;
+
+  /**
+   * @returns The MaskArray which can be used to mask off pairs. By default all
+   * pairs will be enabled.
+   */
+  virtual MaskArraySharedPtr get_mask_array() override;
 };
 
 using CellwisePairListSimpleSharedPtr = std::shared_ptr<CellwisePairListSimple>;

--- a/include/neso_particles/pair_loop/pair_mask.hpp
+++ b/include/neso_particles/pair_loop/pair_mask.hpp
@@ -1,0 +1,102 @@
+#ifndef _NESO_PARTICLES_PAIR_LOOP_PAIR_MASK_HPP_
+#define _NESO_PARTICLES_PAIR_LOOP_PAIR_MASK_HPP_
+
+#include "../containers/mask_array.hpp"
+
+namespace NESO::Particles {
+
+class PairMask;
+
+namespace Access::PairMask {
+
+struct Write {
+  std::size_t entry_index{0};
+  MaskArrayDevice mask_array;
+
+  /**
+   * @returns The current mask value for the pair.
+   */
+  inline bool get() const { return this->mask_array.get(entry_index, 0); }
+
+  /**
+   * Enable this pair. Note that this method is only functionally useful if
+   * for some reason the pair was disabled within the same kernel.
+   */
+  inline void set_on() { this->mask_array.set(entry_index, 0, true); }
+
+  /**
+   * Mask off this pair.
+   */
+  inline void set_off() { this->mask_array.set(entry_index, 0, false); }
+};
+} // namespace Access::PairMask
+
+namespace ParticleLoopImplementation {
+
+/**
+ *  Loop parameter for write access of a PairMask.
+ */
+template <> struct LoopParameter<Access::Write<PairMask>> {
+  using type = MaskArrayDevice;
+};
+
+/**
+ *  KernelParameter type for write access to a PairMask.
+ */
+template <> struct KernelParameter<Access::Write<PairMask>> {
+  using type = Access::PairMask::Write;
+};
+
+} // namespace ParticleLoopImplementation
+
+namespace ParticlePairLoopImplementation {
+
+/**
+ * Function to create the kernel argument for PairMask write
+ * access in a pair loop.
+ */
+inline void create_kernel_arg(
+    [[maybe_unused]] ParticlePairLoopIteration &iteration,
+    [[maybe_unused]] ParticleLoopImplementation::ParticleLoopIteration
+        &iteration_particle,
+    MaskArrayDevice &rhs, Access::PairMask::Write &lhs) {
+  lhs = {static_cast<std::size_t>(iteration.pair_index), rhs};
+}
+
+} // namespace ParticlePairLoopImplementation
+
+class PairMask : public MaskArray {
+protected:
+public:
+  PairMask() = default;
+  virtual ~PairMask() = default;
+
+  /**
+   * Create a pair mask on a given compute device with a set number of bits per
+   * entry.
+   *
+   * @param sycl_target Compute device.
+   */
+  PairMask(SYCLTargetSharedPtr sycl_target);
+};
+
+using PairMaskSharedPtr = std::shared_ptr<PairMask>;
+
+namespace ParticleLoopImplementation {
+
+/**
+ * Method to compute access to a PairMask (write)
+ */
+inline MaskArrayDevice
+create_loop_arg([[maybe_unused]] ParticleLoopGlobalInfo *global_info,
+                [[maybe_unused]] sycl::handler &cgh,
+                Access::Write<PairMask *> &a) {
+  auto tmp = a.obj->get_device();
+  return tmp;
+}
+
+} // namespace ParticleLoopImplementation
+
+} // namespace NESO::Particles
+
+#endif

--- a/include/neso_particles/pair_loop/pair_mask.hpp
+++ b/include/neso_particles/pair_loop/pair_mask.hpp
@@ -87,13 +87,10 @@ namespace ParticleLoopImplementation {
 /**
  * Method to compute access to a PairMask (write)
  */
-inline MaskArrayDevice
+MaskArrayDevice
 create_loop_arg([[maybe_unused]] ParticleLoopGlobalInfo *global_info,
                 [[maybe_unused]] sycl::handler &cgh,
-                Access::Write<PairMask *> &a) {
-  auto tmp = a.obj->get_device();
-  return tmp;
-}
+                Access::Write<PairMask *> &a);
 
 } // namespace ParticleLoopImplementation
 

--- a/include/neso_particles/pair_loop/pair_mask.hpp
+++ b/include/neso_particles/pair_loop/pair_mask.hpp
@@ -65,6 +65,10 @@ inline void create_kernel_arg(
 
 } // namespace ParticlePairLoopImplementation
 
+/**
+ * Specialised MaskArray for enabling/disabling pairs of particles in pair
+ * lists.
+ */
 class PairMask : public MaskArray {
 protected:
 public:

--- a/include/neso_particles/pair_loop/particle_pair_loop_args.hpp
+++ b/include/neso_particles/pair_loop/particle_pair_loop_args.hpp
@@ -4,6 +4,7 @@
 #include "../containers/rng/kernel_rng.hpp"
 #include "../loop/particle_loop_args.hpp"
 #include "../particle_sub_group/particle_sub_group_base.hpp"
+#include "pair_mask.hpp"
 #include "particle_pair_loop_base.hpp"
 #include "particle_pair_loop_index.hpp"
 

--- a/include/neso_particles/pair_loop/particle_pair_loop_cellwise_pair_list.hpp
+++ b/include/neso_particles/pair_loop/particle_pair_loop_cellwise_pair_list.hpp
@@ -28,67 +28,45 @@ protected:
   using ParticlePairLoopArgs<ARGS...>::create_loop_args;
   using ParticlePairLoopArgs<ARGS...>::create_kernel_args;
 
-  std::vector<CellwisePairListDevice> h_pair_lists_device;
-  std::shared_ptr<BufferDevice<CellwisePairListDevice>> d_pair_lists_device;
-  std::size_t num_pair_lists{0};
+  CellwisePairListDevice h_pair_list_device;
   int cell_count{0};
 
-  std::vector<INT> h_pair_list_counts_es;
-  std::shared_ptr<BufferDevice<INT>> d_pair_list_counts_es;
-
   virtual inline std::size_t get_iteration_set_size() override {
-    std::size_t num_pairs = 0;
-    for (const auto &ix : this->h_pair_lists_device) {
-      num_pairs += static_cast<std::size_t>(ix.pair_count);
-    }
-    return num_pairs;
+    return static_cast<std::size_t>(this->h_pair_list_device.pair_count);
   }
 
 public:
-  std::vector<CellwisePairListAbsolute<ParticleGroup, CellwisePairList>>
-      pair_lists;
+  CellwisePairListAbsolute<ParticleGroup, CellwisePairList> pair_list;
   typename GetParticlePairLoopKernelType<KERNEL>::type kernel;
 
   /**
    * Create a ParticlePairLoop from cellwise pair lists.
    *
    * @param name Name for ParticlePairLoop.
-   * @param pair_lists Vector of CellwisePairListAbsolute pair lists.
+   * @param pair_list CellwisePairListAbsolute pair list.
    * @param kernel Kernel for pair loop.
    * @param args... Arguments for pair loop.
    */
   ParticlePairLoopCellwisePairList(
       std::string name,
-      std::vector<CellwisePairListAbsolute<ParticleGroup, CellwisePairList>>
-          pair_lists,
+      CellwisePairListAbsolute<ParticleGroup, CellwisePairList> pair_list,
       KERNEL kernel, ARGS... args)
       : ParticlePairLoopArgs<ARGS...>(nullptr, name, nullptr, nullptr, nullptr,
                                       nullptr, args...),
-        pair_lists(pair_lists), kernel(particle_pair_loop_kernel(kernel)) {
+        pair_list(pair_list), kernel(particle_pair_loop_kernel(kernel)) {
 
-    if (pair_lists.size()) {
-      this->num_pair_lists = pair_lists.size();
-      this->particle_group_A = get_particle_group(pair_lists[0].A);
-      this->particle_group_B = get_particle_group(pair_lists[0].B);
-      NESOASSERT(this->particle_group_A->domain ==
-                     this->particle_group_B->domain,
-                 "Domain missmatch between ParticleGroups.");
+    this->particle_group_A = pair_list.A;
+    this->particle_group_B = pair_list.B;
+    NESOASSERT(this->particle_group_A->domain == this->particle_group_B->domain,
+               "Domain missmatch between ParticleGroups.");
 
-      NESOASSERT(this->particle_group_A->sycl_target ==
-                     this->particle_group_B->sycl_target,
-                 "Compute device missmatch between ParticleGroups.");
+    NESOASSERT(this->particle_group_A->sycl_target ==
+                   this->particle_group_B->sycl_target,
+               "Compute device missmatch between ParticleGroups.");
 
-      this->sycl_target = this->particle_group_A->sycl_target;
-      this->cell_count = this->particle_group_A->domain->mesh->get_cell_count();
-      NESOASSERT(this->sycl_target != nullptr, "Bad compute device found");
-      this->d_pair_lists_device =
-          std::make_shared<BufferDevice<CellwisePairListDevice>>(
-              this->sycl_target, pair_lists.size());
-      this->h_pair_lists_device.resize(pair_lists.size());
-      this->h_pair_list_counts_es.resize(pair_lists.size());
-      this->d_pair_list_counts_es = std::make_shared<BufferDevice<INT>>(
-          this->sycl_target, pair_lists.size());
-    }
+    this->sycl_target = this->particle_group_A->sycl_target;
+    this->cell_count = this->particle_group_A->domain->mesh->get_cell_count();
+    NESOASSERT(this->sycl_target != nullptr, "Bad compute device found");
   }
 
   virtual inline void
@@ -104,24 +82,11 @@ public:
          [[maybe_unused]] const std::optional<int> cell_end =
              std::nullopt) override {
 
-    int max_pair_count = 0;
-    INT pair_list_counts_es = 0;
-    int max_wave_count = 0;
-    for (std::size_t listx = 0; listx < this->num_pair_lists; listx++) {
-      this->h_pair_lists_device[listx] =
-          this->pair_lists[listx].pair_list->get_pair_list();
-      max_pair_count = std::max(
-          max_pair_count, this->h_pair_lists_device[listx].max_pair_count);
-      // Assemble the exclusive counts across the lists.
-      this->h_pair_list_counts_es[listx] = pair_list_counts_es;
-      pair_list_counts_es += this->h_pair_lists_device[listx].pair_count;
-      max_wave_count = std::max(
-          max_wave_count, this->h_pair_lists_device[listx].max_wave_count);
-    }
-    this->event_stack.push(
-        this->d_pair_lists_device->set_async(this->h_pair_lists_device));
-    this->event_stack.push(
-        this->d_pair_list_counts_es->set_async(this->h_pair_list_counts_es));
+    const auto k_pair_list = this->pair_list.pair_list->get_pair_list();
+    this->h_pair_list_device = k_pair_list;
+    // Max pair count of any wave.
+    const int max_pair_count = this->h_pair_list_device.max_pair_count;
+    const int max_wave_count = this->h_pair_list_device.max_wave_count;
 
     // Create global info needs to be called after h_pair_lists_device is set.
     this->create_global_info(cell_start, cell_end, &this->global_info_A,
@@ -135,21 +100,17 @@ public:
     const auto cell_end_actual = this->global_info_A.bounding_cell;
     const int cell_count_iteration = cell_end_actual - cell_start_actual;
 
-    this->event_stack.wait();
-    if ((max_pair_count > 0) && (this->num_pair_lists > 0) &&
-        (cell_count_iteration > 0)) {
+    auto k_kernel = this->kernel.kernel;
+    std::size_t local_size = this->global_info_A.local_size;
 
-      auto k_kernel = this->kernel.kernel;
-      auto k_pair_lists = this->d_pair_lists_device->ptr;
-      auto k_pair_list_counts_es = this->d_pair_list_counts_es->ptr;
-      std::size_t local_size = this->global_info_A.local_size;
+    this->event_stack.wait();
+    if ((max_pair_count > 0) && (cell_count_iteration > 0)) {
 
       if (this->sycl_target->device.is_cpu() || (max_wave_count == 1)) {
 
         sycl::range<3> local_iteration_set(1, 1, local_size);
         sycl::range<3> global_iteration_set(
-            static_cast<std::size_t>(cell_count_iteration),
-            static_cast<std::size_t>(this->num_pair_lists),
+            1, static_cast<std::size_t>(cell_count_iteration),
             static_cast<std::size_t>(local_size));
 
         sycl::nd_range<3> nd_iteration_set =
@@ -157,7 +118,6 @@ public:
                 sycl::nd_range<3>(global_iteration_set, local_iteration_set));
 
         for (int wavex = 0; wavex < max_wave_count; wavex++) {
-
           this->sycl_target->queue
               .submit([&](sycl::handler &cgh) {
                 loop_parameter_type loop_args;
@@ -168,26 +128,23 @@ public:
 
                 cgh.parallel_for(nd_iteration_set, [=](sycl::nd_item<3> idx) {
                   const std::size_t index_cell =
-                      idx.get_global_id(0) + cell_start_actual;
-                  const std::size_t index_list = idx.get_global_id(1);
+                      idx.get_global_id(1) + cell_start_actual;
                   const std::size_t local_id = idx.get_local_linear_id();
                   const std::size_t local_range =
                       idx.get_group().get_local_linear_range();
-                  const INT offset_list = k_pair_list_counts_es[index_list];
 
-                  const auto *pair_list = &k_pair_lists[index_list];
-                  const int wave_count = pair_list->get_num_waves(index_cell);
+                  const int wave_count = k_pair_list.get_num_waves(index_cell);
 
                   if (wavex < wave_count) {
 
                     const auto num_pairs =
-                        static_cast<std::size_t>(pair_list->get_num_pairs(
+                        static_cast<std::size_t>(k_pair_list.get_num_pairs(
                             wavex, static_cast<int>(index_cell)));
 
                     for (std::size_t index_pair = local_id;
                          index_pair < num_pairs; index_pair += local_range) {
 
-                      const INT offset_cell = pair_list->get_pair_linear_index(
+                      const INT pair_index = k_pair_list.get_pair_linear_index(
                           wavex, index_cell, index_pair);
 
                       ParticlePairLoopImplementation::ParticlePairLoopIteration
@@ -200,13 +157,13 @@ public:
                           iteration_B;
 
                       const int particle_index_a =
-                          pair_list->get_particle_index_i(wavex, index_cell,
-                                                          index_pair);
+                          k_pair_list.get_particle_index_i(wavex, index_cell,
+                                                           index_pair);
                       const int particle_index_b =
-                          pair_list->get_particle_index_j(wavex, index_cell,
-                                                          index_pair);
+                          k_pair_list.get_particle_index_j(wavex, index_cell,
+                                                           index_pair);
 
-                      iteration.pair_index = offset_list + offset_cell;
+                      iteration.pair_index = pair_index;
 
                       iteration_A.local_sycl_index = idx.get_local_linear_id();
                       iteration_A.local_sycl_range =
@@ -237,8 +194,7 @@ public:
 
         sycl::range<3> local_iteration_set(1, 1, local_size);
         sycl::range<3> global_iteration_set(
-            static_cast<std::size_t>(cell_count_iteration),
-            static_cast<std::size_t>(this->num_pair_lists),
+            1, static_cast<std::size_t>(cell_count_iteration),
             static_cast<std::size_t>(local_size));
 
         sycl::nd_range<3> nd_iteration_set =
@@ -254,26 +210,23 @@ public:
 
           cgh.parallel_for(nd_iteration_set, [=](sycl::nd_item<3> idx) {
             const std::size_t index_cell =
-                idx.get_global_id(0) + cell_start_actual;
-            const std::size_t index_list = idx.get_global_id(1);
+                idx.get_global_id(1) + cell_start_actual;
             const std::size_t local_id = idx.get_local_linear_id();
             const std::size_t local_range =
                 idx.get_group().get_local_linear_range();
-            const INT offset_list = k_pair_list_counts_es[index_list];
 
-            const auto *pair_list = &k_pair_lists[index_list];
-            const int wave_count = pair_list->get_num_waves(index_cell);
+            const int wave_count = k_pair_list.get_num_waves(index_cell);
 
             for (int wavex = 0; wavex < wave_count; wavex++) {
 
               const auto num_pairs =
-                  static_cast<std::size_t>(pair_list->get_num_pairs(
+                  static_cast<std::size_t>(k_pair_list.get_num_pairs(
                       wavex, static_cast<int>(index_cell)));
 
               for (std::size_t index_pair = local_id; index_pair < num_pairs;
                    index_pair += local_range) {
 
-                const INT offset_cell = pair_list->get_pair_linear_index(
+                const INT pair_index = k_pair_list.get_pair_linear_index(
                     wavex, index_cell, index_pair);
 
                 ParticlePairLoopImplementation::ParticlePairLoopIteration
@@ -283,12 +236,12 @@ public:
                 ParticleLoopImplementation::ParticleLoopIteration iteration_A;
                 ParticleLoopImplementation::ParticleLoopIteration iteration_B;
 
-                const int particle_index_a = pair_list->get_particle_index_i(
+                const int particle_index_a = k_pair_list.get_particle_index_i(
                     wavex, index_cell, index_pair);
-                const int particle_index_b = pair_list->get_particle_index_j(
+                const int particle_index_b = k_pair_list.get_particle_index_j(
                     wavex, index_cell, index_pair);
 
-                iteration.pair_index = offset_list + offset_cell;
+                iteration.pair_index = pair_index;
 
                 iteration_A.local_sycl_index = idx.get_local_linear_id();
                 iteration_A.local_sycl_range =
@@ -323,7 +276,8 @@ public:
 
 /**
  * Create a ParticlePairLoop from cellwise pair lists. This is a helper function
- * to create instances of ParticlePairLoopCellwisePairList.
+ * to create instances of ParticlePairLoopCellwisePairList. This helper function
+ * is for backwards compatibility, the pair_lists vector must be size 1.
  *
  * @param name Name for ParticlePairLoop.
  * @param pair_lists Vector of CellwisePairListAbsolute pair lists.
@@ -337,15 +291,19 @@ inline ParticlePairLoopBaseSharedPtr particle_pair_loop(
     std::vector<CellwisePairListAbsolute<ParticleGroup, CellwisePairList>>
         pair_lists,
     KERNEL kernel, ARGS... args) {
+  NESOASSERT(pair_lists.size() == 1,
+             "Multiple pair lists passed to particle_pair_loop is no longer "
+             "supported.");
   auto ptr =
       std::make_shared<ParticlePairLoopCellwisePairList<KERNEL, ARGS...>>(
-          name, pair_lists, kernel, args...);
+          name, pair_lists[0], kernel, args...);
   return std::dynamic_pointer_cast<ParticlePairLoopBase>(ptr);
 }
 
 /**
  * Create a ParticlePairLoop from cellwise pair lists. This is a helper function
- * to create instances of ParticlePairLoopCellwisePairList.
+ * to create instances of ParticlePairLoopCellwisePairList. This helper function
+ * is for backwards compatibility, the pair_lists vector must be size 1.
  *
  * @param pair_lists Vector of CellwisePairListAbsolute pair lists.
  * @param kernel Kernel for pair loop.
@@ -357,8 +315,45 @@ inline ParticlePairLoopBaseSharedPtr particle_pair_loop(
     std::vector<CellwisePairListAbsolute<ParticleGroup, CellwisePairList>>
         pair_lists,
     KERNEL kernel, ARGS... args) {
-
   return particle_pair_loop("unnamed_particle_pair_loop", pair_lists, kernel,
+                            args...);
+}
+
+/**
+ * Create a ParticlePairLoop from cellwise pair lists. This is a helper function
+ * to create instances of ParticlePairLoopCellwisePairList.
+ *
+ * @param name Name for ParticlePairLoop.
+ * @param pair_list CellwisePairListAbsolute based pair list.
+ * @param kernel Kernel for pair loop.
+ * @param args... Arguments for pair loop.
+ * @returns ParticlePairLoop for iteration set and arguments.
+ */
+template <typename KERNEL, typename... ARGS>
+inline ParticlePairLoopBaseSharedPtr particle_pair_loop(
+    std::string name,
+    CellwisePairListAbsolute<ParticleGroup, CellwisePairList> pair_list,
+    KERNEL kernel, ARGS... args) {
+  auto ptr =
+      std::make_shared<ParticlePairLoopCellwisePairList<KERNEL, ARGS...>>(
+          name, pair_list, kernel, args...);
+  return std::dynamic_pointer_cast<ParticlePairLoopBase>(ptr);
+}
+
+/**
+ * Create a ParticlePairLoop from cellwise pair lists. This is a helper function
+ * to create instances of ParticlePairLoopCellwisePairList.
+ *
+ * @param pair_list CellwisePairListAbsolute based pair list.
+ * @param kernel Kernel for pair loop.
+ * @param args... Arguments for pair loop.
+ * @returns ParticlePairLoop for iteration set and arguments.
+ */
+template <typename KERNEL, typename... ARGS>
+inline ParticlePairLoopBaseSharedPtr particle_pair_loop(
+    CellwisePairListAbsolute<ParticleGroup, CellwisePairList> pair_list,
+    KERNEL kernel, ARGS... args) {
+  return particle_pair_loop("unnamed_particle_pair_loop", pair_list, kernel,
                             args...);
 }
 

--- a/include/neso_particles/pair_loop/particle_pair_loop_cellwise_pair_list.hpp
+++ b/include/neso_particles/pair_loop/particle_pair_loop_cellwise_pair_list.hpp
@@ -147,42 +147,50 @@ public:
                       const INT pair_index = k_pair_list.get_pair_linear_index(
                           wavex, index_cell, index_pair);
 
-                      ParticlePairLoopImplementation::ParticlePairLoopIteration
-                          iteration;
-                      iteration.work_item = &idx;
+                      const bool mask =
+                          k_pair_list.mask_array.get(pair_index, 0);
 
-                      ParticleLoopImplementation::ParticleLoopIteration
-                          iteration_A;
-                      ParticleLoopImplementation::ParticleLoopIteration
-                          iteration_B;
+                      if (mask) {
 
-                      const int particle_index_a =
-                          k_pair_list.get_particle_index_i(wavex, index_cell,
-                                                           index_pair);
-                      const int particle_index_b =
-                          k_pair_list.get_particle_index_j(wavex, index_cell,
-                                                           index_pair);
+                        ParticlePairLoopImplementation::
+                            ParticlePairLoopIteration iteration;
+                        iteration.work_item = &idx;
 
-                      iteration.pair_index = pair_index;
+                        ParticleLoopImplementation::ParticleLoopIteration
+                            iteration_A;
+                        ParticleLoopImplementation::ParticleLoopIteration
+                            iteration_B;
 
-                      iteration_A.local_sycl_index = idx.get_local_linear_id();
-                      iteration_A.local_sycl_range =
-                          idx.get_group().get_local_linear_range();
-                      iteration_A.cellx = index_cell;
-                      iteration_A.layerx = particle_index_a;
+                        const int particle_index_a =
+                            k_pair_list.get_particle_index_i(wavex, index_cell,
+                                                             index_pair);
+                        const int particle_index_b =
+                            k_pair_list.get_particle_index_j(wavex, index_cell,
+                                                             index_pair);
 
-                      iteration_B.local_sycl_index = idx.get_local_linear_id();
-                      iteration_B.local_sycl_range =
-                          idx.get_group().get_local_linear_range();
-                      iteration_B.cellx = index_cell;
-                      iteration_B.layerx = particle_index_b;
+                        iteration.pair_index = pair_index;
 
-                      kernel_parameter_type kernel_args;
-                      KernelMasksType kernel_masks;
+                        iteration_A.local_sycl_index =
+                            idx.get_local_linear_id();
+                        iteration_A.local_sycl_range =
+                            idx.get_group().get_local_linear_range();
+                        iteration_A.cellx = index_cell;
+                        iteration_A.layerx = particle_index_a;
 
-                      create_kernel_args(iteration, kernel_masks, iteration_A,
-                                         iteration_B, loop_args, kernel_args);
-                      Tuple::apply(k_kernel, kernel_args);
+                        iteration_B.local_sycl_index =
+                            idx.get_local_linear_id();
+                        iteration_B.local_sycl_range =
+                            idx.get_group().get_local_linear_range();
+                        iteration_B.cellx = index_cell;
+                        iteration_B.layerx = particle_index_b;
+
+                        kernel_parameter_type kernel_args;
+                        KernelMasksType kernel_masks;
+
+                        create_kernel_args(iteration, kernel_masks, iteration_A,
+                                           iteration_B, loop_args, kernel_args);
+                        Tuple::apply(k_kernel, kernel_args);
+                      }
                     }
                   }
                 });
@@ -228,39 +236,42 @@ public:
 
                 const INT pair_index = k_pair_list.get_pair_linear_index(
                     wavex, index_cell, index_pair);
+                const bool mask = k_pair_list.mask_array.get(pair_index, 0);
 
-                ParticlePairLoopImplementation::ParticlePairLoopIteration
-                    iteration;
-                iteration.work_item = &idx;
+                if (mask) {
+                  ParticlePairLoopImplementation::ParticlePairLoopIteration
+                      iteration;
+                  iteration.work_item = &idx;
 
-                ParticleLoopImplementation::ParticleLoopIteration iteration_A;
-                ParticleLoopImplementation::ParticleLoopIteration iteration_B;
+                  ParticleLoopImplementation::ParticleLoopIteration iteration_A;
+                  ParticleLoopImplementation::ParticleLoopIteration iteration_B;
 
-                const int particle_index_a = k_pair_list.get_particle_index_i(
-                    wavex, index_cell, index_pair);
-                const int particle_index_b = k_pair_list.get_particle_index_j(
-                    wavex, index_cell, index_pair);
+                  const int particle_index_a = k_pair_list.get_particle_index_i(
+                      wavex, index_cell, index_pair);
+                  const int particle_index_b = k_pair_list.get_particle_index_j(
+                      wavex, index_cell, index_pair);
 
-                iteration.pair_index = pair_index;
+                  iteration.pair_index = pair_index;
 
-                iteration_A.local_sycl_index = idx.get_local_linear_id();
-                iteration_A.local_sycl_range =
-                    idx.get_group().get_local_linear_range();
-                iteration_A.cellx = index_cell;
-                iteration_A.layerx = particle_index_a;
+                  iteration_A.local_sycl_index = idx.get_local_linear_id();
+                  iteration_A.local_sycl_range =
+                      idx.get_group().get_local_linear_range();
+                  iteration_A.cellx = index_cell;
+                  iteration_A.layerx = particle_index_a;
 
-                iteration_B.local_sycl_index = idx.get_local_linear_id();
-                iteration_B.local_sycl_range =
-                    idx.get_group().get_local_linear_range();
-                iteration_B.cellx = index_cell;
-                iteration_B.layerx = particle_index_b;
+                  iteration_B.local_sycl_index = idx.get_local_linear_id();
+                  iteration_B.local_sycl_range =
+                      idx.get_group().get_local_linear_range();
+                  iteration_B.cellx = index_cell;
+                  iteration_B.layerx = particle_index_b;
 
-                kernel_parameter_type kernel_args;
-                KernelMasksType kernel_masks;
+                  kernel_parameter_type kernel_args;
+                  KernelMasksType kernel_masks;
 
-                create_kernel_args(iteration, kernel_masks, iteration_A,
-                                   iteration_B, loop_args, kernel_args);
-                Tuple::apply(k_kernel, kernel_args);
+                  create_kernel_args(iteration, kernel_masks, iteration_A,
+                                     iteration_B, loop_args, kernel_args);
+                  Tuple::apply(k_kernel, kernel_args);
+                }
               }
 
               // This barrier seems to cause the atomics in the kernel rng

--- a/src/algorithms/dsmc/pair_sampler_no_replacement.cpp
+++ b/src/algorithms/dsmc/pair_sampler_no_replacement.cpp
@@ -37,7 +37,7 @@ PairSamplerNoReplacement::PairSamplerNoReplacement(
   this->d_max_pair_count =
       std::make_unique<BufferDevice<INT>>(this->sycl_target, 1);
 
-  this->mask_array = std::make_shared<MaskArray>(this->sycl_target, 1);
+  this->pair_mask = std::make_shared<PairMask>(this->sycl_target);
 }
 
 void PairSamplerNoReplacement::sample(
@@ -191,7 +191,7 @@ void PairSamplerNoReplacement::sample(
   e8.wait_and_throw();
 
   this->num_pairs = last_count + last_count_es;
-  this->mask_array->reset(true, this->num_pairs);
+  this->pair_mask->reset(true, this->num_pairs);
 
   // Now we can actually sample pairs.
   const auto k_pair_count = this->num_pairs;
@@ -366,7 +366,7 @@ void PairSamplerNoReplacement::sample(
                               static_cast<int>(max_pair_count),
                               1,
                               this->num_pairs,
-                              this->mask_array->get_device()};
+                              this->pair_mask->get_device()};
 
   this->sycl_target->profile_map.end_region(r0);
 }
@@ -398,8 +398,8 @@ CellwisePairListHostMap PairSamplerNoReplacement::get_host_pair_list() {
 
 INT PairSamplerNoReplacement::get_num_pairs() { return this->num_pairs; }
 
-MaskArraySharedPtr PairSamplerNoReplacement::get_mask_array() {
-  return this->mask_array;
+PairMaskSharedPtr PairSamplerNoReplacement::get_pair_mask() {
+  return this->pair_mask;
 }
 
 } // namespace NESO::Particles::DSMC

--- a/src/algorithms/dsmc/pair_sampler_no_replacement.cpp
+++ b/src/algorithms/dsmc/pair_sampler_no_replacement.cpp
@@ -36,6 +36,8 @@ PairSamplerNoReplacement::PairSamplerNoReplacement(
 
   this->d_max_pair_count =
       std::make_unique<BufferDevice<INT>>(this->sycl_target, 1);
+
+  this->mask_array = std::make_shared<MaskArray>(this->sycl_target, 1);
 }
 
 void PairSamplerNoReplacement::sample(
@@ -189,6 +191,7 @@ void PairSamplerNoReplacement::sample(
   e8.wait_and_throw();
 
   this->num_pairs = last_count + last_count_es;
+  this->mask_array->reset(true, this->num_pairs);
 
   // Now we can actually sample pairs.
   const auto k_pair_count = this->num_pairs;
@@ -362,7 +365,8 @@ void PairSamplerNoReplacement::sample(
                               this->h_pair_counts.data(),
                               static_cast<int>(max_pair_count),
                               1,
-                              this->num_pairs};
+                              this->num_pairs,
+                              this->mask_array->get_device()};
 
   this->sycl_target->profile_map.end_region(r0);
 }
@@ -393,5 +397,9 @@ CellwisePairListHostMap PairSamplerNoReplacement::get_host_pair_list() {
 }
 
 INT PairSamplerNoReplacement::get_num_pairs() { return this->num_pairs; }
+
+MaskArraySharedPtr PairSamplerNoReplacement::get_mask_array() {
+  return this->mask_array;
+}
 
 } // namespace NESO::Particles::DSMC

--- a/src/containers/mask_array.cpp
+++ b/src/containers/mask_array.cpp
@@ -54,4 +54,59 @@ MaskArrayDevice MaskArray::get_device() {
           this->num_masks_per_entry, this->size};
 }
 
+std::size_t MaskArray::get_num_masks_true(const std::size_t mask_index) {
+  auto r0 = this->sycl_target->profile_map.start_region("MaskArray",
+                                                        "get_num_masks_true");
+
+  MaskArrayDevice mad = this->get_device();
+
+  auto d_INT =
+      get_resource<BufferDevice<INT>, ResourceStackInterfaceBufferDevice<INT>>(
+          sycl_target->resource_stack_map, ResourceStackKeyBufferDevice<INT>{},
+          sycl_target);
+  if (d_INT->size < 1) {
+    d_INT->realloc_no_copy(1);
+  }
+
+  INT *k_int = d_INT->ptr;
+  const auto k_size = this->size;
+
+  const INT zero = 0;
+  auto e0 = sycl_target->queue.memcpy(k_int, &zero, sizeof(INT));
+
+  const std::size_t local_size =
+      this->sycl_target->parameters
+          ->template get<SizeTParameter>("LOOP_LOCAL_SIZE")
+          ->value;
+
+  auto e1 = this->sycl_target->queue.parallel_for(
+      this->sycl_target->device_limits.validate_nd_range(sycl::nd_range<1>(
+          sycl::range<1>(local_size * div_round_up(this->size, local_size)),
+          sycl::range<1>(local_size))),
+      e0, [=](sycl::nd_item<1> idx) {
+        int contrib = 0;
+        const std::size_t gid = idx.get_global_linear_id();
+        if (gid < k_size) {
+          const bool v = mad.get(gid, mask_index);
+          contrib = v ? 1 : 0;
+        }
+
+        const int group_reduce_v =
+            reduce_over_group(idx.get_group(), contrib, sycl::plus{});
+
+        if (idx.get_group().leader()) {
+          atomic_fetch_add(k_int, static_cast<INT>(group_reduce_v));
+        }
+      });
+
+  INT result = 0;
+  sycl_target->queue.memcpy(&result, k_int, sizeof(INT), e1).wait_and_throw();
+
+  restore_resource(sycl_target->resource_stack_map,
+                   ResourceStackKeyBufferDevice<INT>{}, d_INT);
+
+  this->sycl_target->profile_map.end_region(r0);
+  return static_cast<std::size_t>(result);
+}
+
 } // namespace NESO::Particles

--- a/src/containers/mask_array.cpp
+++ b/src/containers/mask_array.cpp
@@ -8,6 +8,9 @@ MaskArray::MaskArray(SYCLTargetSharedPtr sycl_target,
                      const std::size_t num_masks_per_entry)
     : sycl_target(sycl_target), num_masks_per_entry(num_masks_per_entry) {
   NESOASSERT(sycl_target != nullptr, "Bad compute device");
+
+  this->num_base_elements_per_entry = div_round_up(
+      num_masks_per_entry, static_cast<std::size_t>(num_bits_per_base));
 }
 
 MaskArrayBaseType MaskArray::get_reset_mask(const bool value) {
@@ -16,17 +19,13 @@ MaskArrayBaseType MaskArray::get_reset_mask(const bool value) {
   return reset_value;
 }
 
-std::size_t MaskArray::get_stride(const std::size_t N) {
-  return div_round_up(N, static_cast<std::size_t>(num_bits_per_base));
-}
-
 void MaskArray::reset(const bool value, std::optional<std::size_t> new_size) {
   this->event.wait_and_throw();
 
   if (new_size != std::nullopt) {
     this->size = new_size.value();
-    this->stride = get_stride(this->size);
-    const std::size_t total_length = this->stride * this->num_masks_per_entry;
+    const std::size_t total_length =
+        this->num_base_elements_per_entry * this->size;
 
     if (total_length) {
       if (this->d_masks == nullptr) {
@@ -39,7 +38,8 @@ void MaskArray::reset(const bool value, std::optional<std::size_t> new_size) {
   }
 
   if (this->d_masks != nullptr) {
-    const std::size_t total_length = this->stride * this->num_masks_per_entry;
+    const std::size_t total_length =
+        this->num_base_elements_per_entry * this->size;
     const MaskArrayBaseType reset_value = this->get_reset_mask(value);
     if (total_length) {
       this->event = this->sycl_target->queue.fill<MaskArrayBaseType>(
@@ -51,7 +51,7 @@ void MaskArray::reset(const bool value, std::optional<std::size_t> new_size) {
 MaskArrayDevice MaskArray::get_device() {
   this->event.wait_and_throw();
   return {this->d_masks != nullptr ? this->d_masks->ptr : nullptr,
-          this->num_masks_per_entry, this->stride};
+          this->num_masks_per_entry, this->size};
 }
 
 } // namespace NESO::Particles

--- a/src/containers/mask_array.cpp
+++ b/src/containers/mask_array.cpp
@@ -16,11 +16,8 @@ MaskArrayBaseType MaskArray::get_reset_mask(const bool value) {
   return reset_value;
 }
 
-std::size_t
-MaskArray::get_num_base_elements(const std::size_t N,
-                                 const std::size_t num_masks_per_entry) {
-  return div_round_up(N * num_masks_per_entry,
-                      static_cast<std::size_t>(num_bits_per_base));
+std::size_t MaskArray::get_stride(const std::size_t N) {
+  return div_round_up(N, static_cast<std::size_t>(num_bits_per_base));
 }
 
 void MaskArray::reset(const bool value, std::optional<std::size_t> new_size) {
@@ -28,9 +25,9 @@ void MaskArray::reset(const bool value, std::optional<std::size_t> new_size) {
 
   if (new_size != std::nullopt) {
     this->size = new_size.value();
-    const std::size_t total_length =
-        div_round_up(this->size * this->num_masks_per_entry,
-                     static_cast<std::size_t>(this->num_bits_per_base));
+    this->stride = get_stride(this->size);
+    const std::size_t total_length = this->stride * this->num_masks_per_entry;
+
     if (total_length) {
       if (this->d_masks == nullptr) {
         this->d_masks = std::make_shared<BufferDevice<MaskArrayBaseType>>(
@@ -42,20 +39,19 @@ void MaskArray::reset(const bool value, std::optional<std::size_t> new_size) {
   }
 
   if (this->d_masks != nullptr) {
-    const std::size_t total_length =
-        div_round_up(this->size * this->num_masks_per_entry,
-                     static_cast<std::size_t>(this->num_bits_per_base));
+    const std::size_t total_length = this->stride * this->num_masks_per_entry;
     const MaskArrayBaseType reset_value = this->get_reset_mask(value);
-
-    this->event = this->sycl_target->queue.fill<MaskArrayBaseType>(
-        this->d_masks->ptr, reset_value, total_length);
+    if (total_length) {
+      this->event = this->sycl_target->queue.fill<MaskArrayBaseType>(
+          this->d_masks->ptr, reset_value, total_length);
+    }
   }
 }
 
 MaskArrayDevice MaskArray::get_device() {
   this->event.wait_and_throw();
   return {this->d_masks != nullptr ? this->d_masks->ptr : nullptr,
-          this->num_masks_per_entry, this->size};
+          this->num_masks_per_entry, this->stride};
 }
 
 } // namespace NESO::Particles

--- a/src/containers/mask_array.cpp
+++ b/src/containers/mask_array.cpp
@@ -109,4 +109,22 @@ std::size_t MaskArray::get_num_masks_true(const std::size_t mask_index) {
   return static_cast<std::size_t>(result);
 }
 
+namespace ParticleLoopImplementation {
+Access::MaskArray::Read
+create_loop_arg([[maybe_unused]] ParticleLoopGlobalInfo *global_info,
+                [[maybe_unused]] sycl::handler &cgh,
+                Access::Read<MaskArray *> &a) {
+  auto tmp = a.obj->get_device();
+  return {tmp.d_masks, tmp.num_masks_per_entry, tmp.size};
+}
+
+Access::MaskArray::Write
+create_loop_arg([[maybe_unused]] ParticleLoopGlobalInfo *global_info,
+                [[maybe_unused]] sycl::handler &cgh,
+                Access::Write<MaskArray *> &a) {
+  auto tmp = a.obj->get_device();
+  return {tmp.d_masks, tmp.num_masks_per_entry, tmp.size};
+}
+} // namespace ParticleLoopImplementation
+
 } // namespace NESO::Particles

--- a/src/containers/mask_array.cpp
+++ b/src/containers/mask_array.cpp
@@ -1,0 +1,61 @@
+#include <neso_particles/containers/mask_array.hpp>
+
+namespace NESO::Particles {
+
+MaskArray::~MaskArray() { this->event.wait(); }
+
+MaskArray::MaskArray(SYCLTargetSharedPtr sycl_target,
+                     const std::size_t num_masks_per_entry)
+    : sycl_target(sycl_target), num_masks_per_entry(num_masks_per_entry) {
+  NESOASSERT(sycl_target != nullptr, "Bad compute device");
+}
+
+MaskArrayBaseType MaskArray::get_reset_mask(const bool value) {
+  constexpr MaskArrayBaseType reset_base{0};
+  const MaskArrayBaseType reset_value = value ? ~reset_base : reset_base;
+  return reset_value;
+}
+
+std::size_t
+MaskArray::get_num_base_elements(const std::size_t N,
+                                 const std::size_t num_masks_per_entry) {
+  return div_round_up(N * num_masks_per_entry,
+                      static_cast<std::size_t>(num_bits_per_base));
+}
+
+void MaskArray::reset(const bool value, std::optional<std::size_t> new_size) {
+  this->event.wait_and_throw();
+
+  if (new_size != std::nullopt) {
+    this->size = new_size.value();
+    const std::size_t total_length =
+        div_round_up(this->size * this->num_masks_per_entry,
+                     static_cast<std::size_t>(this->num_bits_per_base));
+    if (total_length) {
+      if (this->d_masks == nullptr) {
+        this->d_masks = std::make_shared<BufferDevice<MaskArrayBaseType>>(
+            this->sycl_target, total_length);
+      } else {
+        this->d_masks->realloc_no_copy(total_length);
+      }
+    }
+  }
+
+  if (this->d_masks != nullptr) {
+    const std::size_t total_length =
+        div_round_up(this->size * this->num_masks_per_entry,
+                     static_cast<std::size_t>(this->num_bits_per_base));
+    const MaskArrayBaseType reset_value = this->get_reset_mask(value);
+
+    this->event = this->sycl_target->queue.fill<MaskArrayBaseType>(
+        this->d_masks->ptr, reset_value, total_length);
+  }
+}
+
+MaskArrayDevice MaskArray::get_device() {
+  this->event.wait_and_throw();
+  return {this->d_masks != nullptr ? this->d_masks->ptr : nullptr,
+          this->num_masks_per_entry, this->size};
+}
+
+} // namespace NESO::Particles

--- a/src/pair_loop/cellwise_pair_list_simple.cpp
+++ b/src/pair_loop/cellwise_pair_list_simple.cpp
@@ -163,6 +163,7 @@ void CellwisePairListSimple::set(CellwisePairListHostSharedPtr pair_list) {
   {
 
     INT linear_offset = 0;
+    std::size_t total_num_pairs = 0;
     for (int cellx = 0; cellx < this->cell_count; cellx++) {
       const int wave_count = m[cellx].size();
 
@@ -177,10 +178,13 @@ void CellwisePairListSimple::set(CellwisePairListHostSharedPtr pair_list) {
         num_pairs += num_pairs_wave;
         linear_offset += num_pairs_wave;
       }
+      total_num_pairs += static_cast<std::size_t>(num_pairs);
       if (num_pairs) {
         this->d_pair_list->set_nrow(cellx, num_pairs);
       }
     }
+
+    this->pair_mask->reset(true, total_num_pairs);
 
     if (max_wave_count) {
       event_stack.push(this->sycl_target->queue.memcpy(

--- a/src/pair_loop/cellwise_pair_list_simple.cpp
+++ b/src/pair_loop/cellwise_pair_list_simple.cpp
@@ -16,7 +16,8 @@ CellwisePairListSimple::CellwisePairListSimple(SYCLTargetSharedPtr sycl_target,
       d_pair_counts_es(
           std::make_shared<BufferDevice<INT>>(sycl_target, cell_count)),
       h_pair_counts(std::vector<int>(cell_count)), sycl_target(sycl_target),
-      cell_count(cell_count) {
+      cell_count(cell_count),
+      mask_array(std::make_shared<MaskArray>(sycl_target, 1)) {
   this->clear();
 }
 
@@ -34,6 +35,8 @@ void CellwisePairListSimple::push_back(const std::vector<int> &c,
   if (n == 0) {
     return;
   }
+
+  this->mask_array->reset(true, n);
 
   std::vector<int> layers(n);
   this->d_pair_counts->get(this->h_pair_counts);
@@ -262,7 +265,8 @@ CellwisePairListDevice CellwisePairListSimple::get_pair_list() {
                               this->h_pair_counts.data(),
                               this->max_pair_count,
                               this->max_wave_count,
-                              this->pair_count};
+                              this->pair_count,
+                              this->mask_array->get_device()};
 
   return l;
 }
@@ -289,5 +293,9 @@ CellwisePairListHostMap CellwisePairListSimple::get_host_pair_list() {
 }
 
 INT CellwisePairListSimple::get_num_pairs() { return this->pair_count; }
+
+MaskArraySharedPtr CellwisePairListSimple::get_mask_array() {
+  return this->mask_array;
+}
 
 } // namespace NESO::Particles

--- a/src/pair_loop/cellwise_pair_list_simple.cpp
+++ b/src/pair_loop/cellwise_pair_list_simple.cpp
@@ -17,7 +17,7 @@ CellwisePairListSimple::CellwisePairListSimple(SYCLTargetSharedPtr sycl_target,
           std::make_shared<BufferDevice<INT>>(sycl_target, cell_count)),
       h_pair_counts(std::vector<int>(cell_count)), sycl_target(sycl_target),
       cell_count(cell_count),
-      mask_array(std::make_shared<MaskArray>(sycl_target, 1)) {
+      pair_mask(std::make_shared<PairMask>(sycl_target)) {
   this->clear();
 }
 
@@ -36,7 +36,7 @@ void CellwisePairListSimple::push_back(const std::vector<int> &c,
     return;
   }
 
-  this->mask_array->reset(true, n);
+  this->pair_mask->reset(true, n);
 
   std::vector<int> layers(n);
   this->d_pair_counts->get(this->h_pair_counts);
@@ -266,7 +266,7 @@ CellwisePairListDevice CellwisePairListSimple::get_pair_list() {
                               this->max_pair_count,
                               this->max_wave_count,
                               this->pair_count,
-                              this->mask_array->get_device()};
+                              this->pair_mask->get_device()};
 
   return l;
 }
@@ -294,8 +294,8 @@ CellwisePairListHostMap CellwisePairListSimple::get_host_pair_list() {
 
 INT CellwisePairListSimple::get_num_pairs() { return this->pair_count; }
 
-MaskArraySharedPtr CellwisePairListSimple::get_mask_array() {
-  return this->mask_array;
+PairMaskSharedPtr CellwisePairListSimple::get_pair_mask() {
+  return this->pair_mask;
 }
 
 } // namespace NESO::Particles

--- a/src/pair_loop/pair_mask.cpp
+++ b/src/pair_loop/pair_mask.cpp
@@ -1,0 +1,8 @@
+#include <neso_particles/pair_loop/pair_mask.hpp>
+
+namespace NESO::Particles {
+
+PairMask::PairMask(SYCLTargetSharedPtr sycl_target)
+    : MaskArray(sycl_target, 1) {}
+
+} // namespace NESO::Particles

--- a/src/pair_loop/pair_mask.cpp
+++ b/src/pair_loop/pair_mask.cpp
@@ -5,4 +5,19 @@ namespace NESO::Particles {
 PairMask::PairMask(SYCLTargetSharedPtr sycl_target)
     : MaskArray(sycl_target, 1) {}
 
+namespace ParticleLoopImplementation {
+
+/**
+ * Method to compute access to a PairMask (write)
+ */
+MaskArrayDevice
+create_loop_arg([[maybe_unused]] ParticleLoopGlobalInfo *global_info,
+                [[maybe_unused]] sycl::handler &cgh,
+                Access::Write<PairMask *> &a) {
+  auto tmp = a.obj->get_device();
+  return tmp;
+}
+
+} // namespace ParticleLoopImplementation
+
 } // namespace NESO::Particles

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -100,6 +100,7 @@ set(TEST_SRCS
     ${TEST_DIR}/test_particle_sub_group_partition_b.cpp
     ${TEST_DIR}/test_particle_sub_group_partition_c.cpp
     ${TEST_DIR}/test_product_matrix.cpp
+    ${TEST_DIR}/test_mask_array.cpp
     ${TEST_DIR}/test_resource_stack.cpp
     ${TEST_DIR}/test_serial_container.cpp
     ${TEST_DIR}/test_selector_exclusive_scan.cpp

--- a/test/test_mask_array.cpp
+++ b/test/test_mask_array.cpp
@@ -3,6 +3,56 @@
 TEST(MaskArray, base) {
   auto sycl_target = std::make_shared<SYCLTarget>(0, MPI_COMM_WORLD);
 
+  MaskArrayDevice h_mad = {nullptr, 2, 14};
+
+  for (MaskArrayBaseType ix = 0; ix < h_mad.num_bits_per_base; ix++) {
+    ASSERT_EQ(h_mad.get_inner_index(7 + ix, 0),
+              (7 + ix) % h_mad.num_bits_per_base);
+    ASSERT_EQ(h_mad.get_outer_index(7 + ix, 0),
+              (7 + ix) / h_mad.num_bits_per_base);
+  }
+
+  MaskArrayBaseType b = 0;
+  for (MaskArrayBaseType ix = 0; ix < h_mad.num_bits_per_base; ix++) {
+    h_mad.set_inner(&b, ix, true);
+    ASSERT_EQ(sycl::popcount(b), ix + 1);
+    ASSERT_EQ(h_mad.get_inner(&b, ix), true);
+    for (MaskArrayBaseType jx = 0; jx < ix; jx++) {
+      ASSERT_EQ(h_mad.get_inner(&b, jx), true);
+    }
+    for (MaskArrayBaseType jx = ix + 1; jx < h_mad.num_bits_per_base; jx++) {
+      ASSERT_EQ(h_mad.get_inner(&b, jx), false);
+    }
+  }
+  for (MaskArrayBaseType ix = 0; ix < h_mad.num_bits_per_base; ix++) {
+    h_mad.set_inner(&b, ix, false);
+    ASSERT_EQ(h_mad.get_inner(&b, ix), false);
+    ASSERT_EQ(sycl::popcount(b), h_mad.num_bits_per_base - ix - 1);
+    for (MaskArrayBaseType jx = 0; jx < ix; jx++) {
+      ASSERT_EQ(h_mad.get_inner(&b, jx), false);
+    }
+    for (MaskArrayBaseType jx = ix + 1; jx < h_mad.num_bits_per_base; jx++) {
+      ASSERT_EQ(h_mad.get_inner(&b, jx), true);
+    }
+  }
+
+  ErrorPropagate ep(sycl_target);
+  auto k_ep = ep.device_ptr();
+  sycl_target->queue.single_task([=]() {
+    MaskArrayBaseType b = 0;
+    for (MaskArrayBaseType ix = 0; ix < h_mad.num_bits_per_base; ix++) {
+      h_mad.set_inner(&b, ix, true);
+      NESO_KERNEL_ASSERT(sycl::popcount(b) == ix + 1, k_ep);
+    }
+    for (MaskArrayBaseType ix = 0; ix < h_mad.num_bits_per_base; ix++) {
+      h_mad.set_inner(&b, ix, false);
+      NESO_KERNEL_ASSERT(sycl::popcount(b) == h_mad.num_bits_per_base - ix - 1,
+                         k_ep);
+    }
+  });
+
+  ASSERT_FALSE(ep.get_flag());
+
   std::vector<MaskArrayDevice> h_ma;
 
   for (std::size_t B : {0, 1, 2}) {

--- a/test/test_mask_array.cpp
+++ b/test/test_mask_array.cpp
@@ -352,8 +352,8 @@ TEST(PairMask, particle_pair_loop) {
 
   particle_pair_loop(
       "particle_pair_loop_test",
-      {CellwisePairListAbsolute<ParticleGroup, CellwisePairList>(
-          A, A, cellwise_pair_list)},
+      CellwisePairListAbsolute<ParticleGroup, CellwisePairList>(
+          A, A, cellwise_pair_list),
       [=](auto MASK_ARRAY) {
         NESO_KERNEL_ASSERT(MASK_ARRAY.get() == true, k_ep);
       },

--- a/test/test_mask_array.cpp
+++ b/test/test_mask_array.cpp
@@ -285,6 +285,9 @@ TEST(MaskArray, particle_pair_loop) {
       ->execute();
   ASSERT_FALSE(ep.get_flag());
 
+  const INT num_set = ma->get_num_masks_true(0);
+  ASSERT_EQ(num_set, cellwise_pair_list->get_num_pairs());
+
   sycl_target->free();
   A->domain->mesh->free();
 }

--- a/test/test_mask_array.cpp
+++ b/test/test_mask_array.cpp
@@ -184,7 +184,6 @@ TEST(MaskArray, particle_loop) {
   for (std::size_t B : {1, 2, 3, 7, 33, 65}) {
 
     auto ma = std::make_shared<MaskArray>(sycl_target, B);
-
     ma->reset(false, A->get_npart_local());
 
     particle_loop(
@@ -215,6 +214,76 @@ TEST(MaskArray, particle_loop) {
 
     ASSERT_FALSE(ep.get_flag());
   }
+
+  sycl_target->free();
+  A->domain->mesh->free();
+}
+
+TEST(MaskArray, particle_pair_loop) {
+
+  const int npart_cell = 257;
+  const int ndim = 2;
+  const int nx = 16;
+  const int ny = 33;
+  const int nz = 48;
+
+  auto [A_t, sycl_target_t, cell_count_t] =
+      particle_loop_create_common(npart_cell, ndim, nx, ny, nz);
+  auto A = A_t;
+  auto sycl_target = sycl_target_t;
+  auto cell_count = cell_count_t;
+
+  const int num_samples = cell_count * npart_cell * 0.2;
+  std::vector<int> h_c(num_samples);
+  std::vector<int> h_i(num_samples);
+  std::vector<int> h_j(num_samples);
+
+  std::mt19937 rng(522342 + sycl_target->comm_pair.rank_parent);
+  std::uniform_int_distribution<int> dist_cell(0, cell_count - 1);
+
+  for (int ix = 0; ix < num_samples; ix++) {
+    const int cell = dist_cell(rng);
+    h_c[ix] = cell;
+    const int npart_cell = A->get_npart_cell(cell);
+    std::uniform_int_distribution<int> dist_layer(0, npart_cell - 1);
+    h_i[ix] = dist_layer(rng);
+    h_j[ix] = dist_layer(rng);
+  }
+
+  auto cellwise_pair_list =
+      std::make_shared<CellwisePairListSimple>(sycl_target, cell_count);
+  cellwise_pair_list->push_back(h_c, h_i, h_j);
+
+  auto ma = std::make_shared<MaskArray>(sycl_target, 1);
+  ma->reset(false, cellwise_pair_list->get_num_pairs());
+
+  ErrorPropagate ep(sycl_target);
+  auto k_ep = ep.device_ptr();
+
+  particle_pair_loop(
+      "particle_pair_loop_test",
+      {CellwisePairListAbsolute<ParticleGroup, CellwisePairList>(
+          A, A, cellwise_pair_list)},
+      [=](auto INDEX, auto MASK_ARRAY) {
+        NESO_KERNEL_ASSERT(
+            MASK_ARRAY.get(INDEX.get_loop_linear_index(), 0) == false, k_ep);
+        MASK_ARRAY.set(INDEX.get_loop_linear_index(), 0, true);
+      },
+      Access::read(ParticlePairLoopIndex{}), Access::write(ma))
+      ->execute();
+  ASSERT_FALSE(ep.get_flag());
+
+  particle_pair_loop(
+      "particle_pair_loop_test",
+      {CellwisePairListAbsolute<ParticleGroup, CellwisePairList>(
+          A, A, cellwise_pair_list)},
+      [=](auto INDEX, auto MASK_ARRAY) {
+        NESO_KERNEL_ASSERT(MASK_ARRAY.get(INDEX.get_loop_linear_index(), 0),
+                           k_ep);
+      },
+      Access::read(ParticlePairLoopIndex{}), Access::read(ma))
+      ->execute();
+  ASSERT_FALSE(ep.get_flag());
 
   sycl_target->free();
   A->domain->mesh->free();

--- a/test/test_mask_array.cpp
+++ b/test/test_mask_array.cpp
@@ -54,7 +54,6 @@ TEST(MaskArray, base) {
   ASSERT_FALSE(ep.get_flag());
 
   std::vector<MaskArrayBaseType> h_ma;
-
   for (std::size_t B : {0, 1, 2}) {
     for (std::size_t N : {0, 1, 4, 31, 61, 32}) {
       auto ma = std::make_shared<MaskArray>(sycl_target, B);
@@ -76,13 +75,13 @@ TEST(MaskArray, base) {
       ma->reset(true, N);
       ASSERT_EQ(ma->size, N);
 
-      const MaskArrayDevice d_ma = ma->get_device();
+      MaskArrayDevice d_ma = ma->get_device();
 
       ASSERT_EQ(d_ma.num_masks_per_entry, B);
       ASSERT_EQ(d_ma.stride, ma->stride);
       ASSERT_EQ(stride, ma->stride);
 
-      const std::size_t M = stride * B;
+      const std::size_t M = stride * ma->num_masks_per_entry;
 
       ASSERT_TRUE(M * ma->num_bits_per_base >= N * B);
 
@@ -121,13 +120,50 @@ TEST(MaskArray, base) {
       }
       ASSERT_EQ(count, static_cast<int>(N * B));
 
+      ma->reset(false, N);
+      d_ma = ma->get_device();
+      sycl_target->queue
+          .memcpy(h_ma.data(), d_ma.d_masks, M * sizeof(MaskArrayBaseType))
+          .wait_and_throw();
+      for (std::size_t ix = 0; ix < M; ix++) {
+        ASSERT_EQ(h_ma.at(ix), static_cast<MaskArrayBaseType>(0));
+      }
+
+      sycl_target->queue
+          .single_task([=]() {
+            for (std::size_t ix = 0; ix < (N * B); ix++) {
+
+              const std::size_t ex = ix / B;
+              const std::size_t bx = ix % B;
+              d_ma.set(ex, bx, true);
+
+              for (std::size_t jx = 0; jx <= ix; jx++) {
+                const std::size_t ex = jx / B;
+                const std::size_t bx = jx % B;
+                NESO_KERNEL_ASSERT(d_ma.get(ex, bx), k_ep);
+              }
+
+              for (std::size_t jx = ix + 1; jx < (N * B); jx++) {
+                const std::size_t ex = jx / B;
+                const std::size_t bx = jx % B;
+                NESO_KERNEL_ASSERT(!d_ma.get(ex, bx), k_ep);
+              }
+            }
+          })
+          .wait_and_throw();
+
+      ASSERT_FALSE(ep.get_flag());
+
+      std::fill(h_ma.begin(), h_ma.end(), 0);
       sycl_target->queue
           .memcpy(h_ma.data(), d_ma.d_masks, M * sizeof(MaskArrayBaseType))
           .wait_and_throw();
 
-      for (std::size_t ix = 0; ix < M; ix++) {
-        ASSERT_EQ(h_ma.at(ix), ~static_cast<MaskArrayBaseType>(0));
+      count = 0;
+      for (auto ix : h_ma) {
+        count += sycl::popcount(ix);
       }
+      ASSERT_EQ(count, static_cast<int>(N * B));
     }
   }
   sycl_target->free();

--- a/test/test_mask_array.cpp
+++ b/test/test_mask_array.cpp
@@ -341,6 +341,10 @@ TEST(PairMask, particle_pair_loop) {
         NESO_KERNEL_ASSERT(MASK_ARRAY.get() == false, k_ep);
         MASK_ARRAY.set_on();
         NESO_KERNEL_ASSERT(MASK_ARRAY.get() == true, k_ep);
+        MASK_ARRAY.set_off();
+        NESO_KERNEL_ASSERT(MASK_ARRAY.get() == false, k_ep);
+        MASK_ARRAY.set_on();
+        NESO_KERNEL_ASSERT(MASK_ARRAY.get() == true, k_ep);
       },
       Access::write(ma))
       ->execute();

--- a/test/test_mask_array.cpp
+++ b/test/test_mask_array.cpp
@@ -1,0 +1,44 @@
+#include "include/test_neso_particles.hpp"
+
+TEST(MaskArray, base) {
+  auto sycl_target = std::make_shared<SYCLTarget>(0, MPI_COMM_WORLD);
+
+  std::vector<MaskArrayDevice> h_ma;
+
+  for (std::size_t B : {0, 1, 2}) {
+    for (std::size_t N : {0, 1, 31, 61, 32}) {
+      auto ma = std::make_shared<MaskArray>(sycl_target, B);
+
+      auto lambda_test = [&](const bool value) {
+        const std::uint32_t correct_popcount =
+            value ? sizeof(MaskArrayBaseType) * CHAR_BIT : 0;
+        const MaskArrayBaseType reset_value = ma->get_reset_mask(value);
+        NESOASSERT(sycl::popcount(reset_value) == correct_popcount,
+                   "Failed to compute correct reset value.");
+      };
+
+      lambda_test(true);
+      lambda_test(false);
+
+      ASSERT_EQ(ma->size, 0);
+      ma->reset(true, N);
+      ASSERT_EQ(ma->size, N);
+
+      const MaskArrayDevice d_ma = ma->get_device();
+
+      ASSERT_EQ(d_ma.num_masks_per_entry, B);
+      ASSERT_EQ(d_ma.size, ma->size);
+
+      const std::size_t M = ma->get_num_base_elements(N, B);
+      ASSERT_TRUE(M * ma->num_bits_per_base >= N * B);
+
+      h_ma.clear();
+      h_ma.resize(M);
+
+      sycl_target->queue
+          .memcpy(h_ma.data(), d_ma.d_masks, M * sizeof(MaskArrayBaseType))
+          .wait_and_throw();
+    }
+  }
+  sycl_target->free();
+}

--- a/test/test_mask_array.cpp
+++ b/test/test_mask_array.cpp
@@ -291,3 +291,75 @@ TEST(MaskArray, particle_pair_loop) {
   sycl_target->free();
   A->domain->mesh->free();
 }
+
+TEST(PairMask, particle_pair_loop) {
+
+  const int npart_cell = 257;
+  const int ndim = 2;
+  const int nx = 16;
+  const int ny = 33;
+  const int nz = 48;
+
+  auto [A_t, sycl_target_t, cell_count_t] =
+      particle_loop_create_common(npart_cell, ndim, nx, ny, nz);
+  auto A = A_t;
+  auto sycl_target = sycl_target_t;
+  auto cell_count = cell_count_t;
+
+  const int num_samples = cell_count * npart_cell * 0.2;
+  std::vector<int> h_c(num_samples);
+  std::vector<int> h_i(num_samples);
+  std::vector<int> h_j(num_samples);
+
+  std::mt19937 rng(522342 + sycl_target->comm_pair.rank_parent);
+  std::uniform_int_distribution<int> dist_cell(0, cell_count - 1);
+
+  for (int ix = 0; ix < num_samples; ix++) {
+    const int cell = dist_cell(rng);
+    h_c[ix] = cell;
+    const int npart_cell = A->get_npart_cell(cell);
+    std::uniform_int_distribution<int> dist_layer(0, npart_cell - 1);
+    h_i[ix] = dist_layer(rng);
+    h_j[ix] = dist_layer(rng);
+  }
+
+  auto cellwise_pair_list =
+      std::make_shared<CellwisePairListSimple>(sycl_target, cell_count);
+  cellwise_pair_list->push_back(h_c, h_i, h_j);
+
+  auto ma = std::make_shared<PairMask>(sycl_target);
+  ma->reset(false, cellwise_pair_list->get_num_pairs());
+
+  ErrorPropagate ep(sycl_target);
+  auto k_ep = ep.device_ptr();
+
+  particle_pair_loop(
+      "particle_pair_loop_test",
+      {CellwisePairListAbsolute<ParticleGroup, CellwisePairList>(
+          A, A, cellwise_pair_list)},
+      [=](auto MASK_ARRAY) {
+        NESO_KERNEL_ASSERT(MASK_ARRAY.get() == false, k_ep);
+        MASK_ARRAY.set_on();
+        NESO_KERNEL_ASSERT(MASK_ARRAY.get() == true, k_ep);
+      },
+      Access::write(ma))
+      ->execute();
+  ASSERT_FALSE(ep.get_flag());
+
+  particle_pair_loop(
+      "particle_pair_loop_test",
+      {CellwisePairListAbsolute<ParticleGroup, CellwisePairList>(
+          A, A, cellwise_pair_list)},
+      [=](auto MASK_ARRAY) {
+        NESO_KERNEL_ASSERT(MASK_ARRAY.get() == true, k_ep);
+      },
+      Access::write(ma))
+      ->execute();
+  ASSERT_FALSE(ep.get_flag());
+
+  const INT num_set = ma->get_num_masks_true(0);
+  ASSERT_EQ(num_set, cellwise_pair_list->get_num_pairs());
+
+  sycl_target->free();
+  A->domain->mesh->free();
+}

--- a/test/test_mask_array.cpp
+++ b/test/test_mask_array.cpp
@@ -53,10 +53,10 @@ TEST(MaskArray, base) {
 
   ASSERT_FALSE(ep.get_flag());
 
-  std::vector<MaskArrayDevice> h_ma;
+  std::vector<MaskArrayBaseType> h_ma;
 
   for (std::size_t B : {0, 1, 2}) {
-    for (std::size_t N : {0, 1, 31, 61, 32}) {
+    for (std::size_t N : {0, 1, 4, 31, 61, 32}) {
       auto ma = std::make_shared<MaskArray>(sycl_target, B);
 
       auto lambda_test = [&](const bool value) {
@@ -70,6 +70,8 @@ TEST(MaskArray, base) {
       lambda_test(true);
       lambda_test(false);
 
+      const std::size_t stride = ma->get_stride(N);
+
       ASSERT_EQ(ma->size, 0);
       ma->reset(true, N);
       ASSERT_EQ(ma->size, N);
@@ -77,17 +79,55 @@ TEST(MaskArray, base) {
       const MaskArrayDevice d_ma = ma->get_device();
 
       ASSERT_EQ(d_ma.num_masks_per_entry, B);
-      ASSERT_EQ(d_ma.size, ma->size);
+      ASSERT_EQ(d_ma.stride, ma->stride);
+      ASSERT_EQ(stride, ma->stride);
 
-      const std::size_t M = ma->get_num_base_elements(N, B);
+      const std::size_t M = stride * B;
+
       ASSERT_TRUE(M * ma->num_bits_per_base >= N * B);
 
       h_ma.clear();
       h_ma.resize(M);
+      std::fill(h_ma.begin(), h_ma.end(), 0);
+      MaskArrayDevice h_mad = {h_ma.data(), d_ma.num_masks_per_entry, stride};
+
+      std::deque<std::pair<std::size_t, std::size_t>> a;
+      std::deque<std::pair<std::size_t, std::size_t>> b;
+
+      for (std::size_t ix = 0; ix < N; ix++) {
+        for (std::size_t jx = 0; jx < B; jx++) {
+          a.push_back({ix, jx});
+        }
+      }
+
+      while (!a.empty()) {
+        auto [ix, bx] = a.back();
+        h_mad.set(ix, bx, true);
+        b.push_back({ix, bx});
+        a.pop_back();
+
+        for (auto &jx : b) {
+          ASSERT_TRUE(h_mad.get(jx.first, jx.second));
+        }
+
+        for (auto &jx : a) {
+          ASSERT_FALSE(h_mad.get(jx.first, jx.second));
+        }
+      }
+
+      int count = 0;
+      for (auto ix : h_ma) {
+        count += sycl::popcount(ix);
+      }
+      ASSERT_EQ(count, static_cast<int>(N * B));
 
       sycl_target->queue
           .memcpy(h_ma.data(), d_ma.d_masks, M * sizeof(MaskArrayBaseType))
           .wait_and_throw();
+
+      for (std::size_t ix = 0; ix < M; ix++) {
+        ASSERT_EQ(h_ma.at(ix), ~static_cast<MaskArrayBaseType>(0));
+      }
     }
   }
   sycl_target->free();

--- a/test/test_mask_array.cpp
+++ b/test/test_mask_array.cpp
@@ -337,16 +337,21 @@ TEST(PairMask, particle_pair_loop) {
       "particle_pair_loop_test",
       {CellwisePairListAbsolute<ParticleGroup, CellwisePairList>(
           A, A, cellwise_pair_list)},
-      [=](auto MASK_ARRAY) {
+      [=](auto INDEX, auto MASK_ARRAY) {
+        const std::size_t i = INDEX.get_loop_linear_index();
         NESO_KERNEL_ASSERT(MASK_ARRAY.get() == false, k_ep);
+        NESO_KERNEL_ASSERT(MASK_ARRAY.mask_array.get(i, 0) == false, k_ep);
         MASK_ARRAY.set_on();
         NESO_KERNEL_ASSERT(MASK_ARRAY.get() == true, k_ep);
+        NESO_KERNEL_ASSERT(MASK_ARRAY.mask_array.get(i, 0) == true, k_ep);
         MASK_ARRAY.set_off();
         NESO_KERNEL_ASSERT(MASK_ARRAY.get() == false, k_ep);
+        NESO_KERNEL_ASSERT(MASK_ARRAY.mask_array.get(i, 0) == false, k_ep);
         MASK_ARRAY.set_on();
         NESO_KERNEL_ASSERT(MASK_ARRAY.get() == true, k_ep);
+        NESO_KERNEL_ASSERT(MASK_ARRAY.mask_array.get(i, 0) == true, k_ep);
       },
-      Access::write(ma))
+      Access::read(ParticlePairLoopIndex{}), Access::write(ma))
       ->execute();
   ASSERT_FALSE(ep.get_flag());
 

--- a/test/test_mask_array.cpp
+++ b/test/test_mask_array.cpp
@@ -364,6 +364,32 @@ TEST(PairMask, particle_pair_loop) {
   const INT num_set = ma->get_num_masks_true(0);
   ASSERT_EQ(num_set, cellwise_pair_list->get_num_pairs());
 
+  auto la_count = std::make_shared<LocalArray<int>>(sycl_target, 1);
+  la_count->fill(0);
+
+  particle_pair_loop(
+      "particle_pair_loop_test",
+      CellwisePairListAbsolute<ParticleGroup, CellwisePairList>(
+          A, A, cellwise_pair_list),
+      [=](auto PAIR_MASK, auto LA_COUNT) {
+        PAIR_MASK.set_off();
+        LA_COUNT.fetch_add(0, 1);
+      },
+      Access::write(cellwise_pair_list->get_pair_mask()), Access::add(la_count))
+      ->execute();
+
+  ASSERT_EQ(la_count->get().at(0), cellwise_pair_list->get_num_pairs());
+
+  la_count->fill(0);
+  particle_pair_loop(
+      "particle_pair_loop_test",
+      CellwisePairListAbsolute<ParticleGroup, CellwisePairList>(
+          A, A, cellwise_pair_list),
+      [=](auto LA_COUNT) { LA_COUNT.fetch_add(0, 1); }, Access::add(la_count))
+      ->execute();
+
+  ASSERT_EQ(la_count->get().at(0), 0);
+
   sycl_target->free();
   A->domain->mesh->free();
 }

--- a/test/test_mask_array.cpp
+++ b/test/test_mask_array.cpp
@@ -6,9 +6,9 @@ TEST(MaskArray, base) {
   MaskArrayDevice h_mad = {nullptr, 2, 14};
 
   for (MaskArrayBaseType ix = 0; ix < h_mad.num_bits_per_base; ix++) {
-    ASSERT_EQ(h_mad.get_inner_index(7 + ix, 0),
+    ASSERT_EQ(h_mad.get_inner_index(0, 7 + ix),
               (7 + ix) % h_mad.num_bits_per_base);
-    ASSERT_EQ(h_mad.get_outer_index(7 + ix, 0),
+    ASSERT_EQ(h_mad.get_outer_index(0, 7 + ix),
               (7 + ix) / h_mad.num_bits_per_base);
   }
 
@@ -69,26 +69,25 @@ TEST(MaskArray, base) {
       lambda_test(true);
       lambda_test(false);
 
-      const std::size_t stride = ma->get_stride(N);
-
       ASSERT_EQ(ma->size, 0);
       ma->reset(true, N);
       ASSERT_EQ(ma->size, N);
 
+      const std::size_t size = ma->size;
       MaskArrayDevice d_ma = ma->get_device();
 
       ASSERT_EQ(d_ma.num_masks_per_entry, B);
-      ASSERT_EQ(d_ma.stride, ma->stride);
-      ASSERT_EQ(stride, ma->stride);
+      ASSERT_EQ(d_ma.size, ma->size);
+      ASSERT_EQ(size, ma->size);
 
-      const std::size_t M = stride * ma->num_masks_per_entry;
+      const std::size_t M = size * ma->num_base_elements_per_entry;
 
       ASSERT_TRUE(M * ma->num_bits_per_base >= N * B);
 
       h_ma.clear();
       h_ma.resize(M);
       std::fill(h_ma.begin(), h_ma.end(), 0);
-      MaskArrayDevice h_mad = {h_ma.data(), d_ma.num_masks_per_entry, stride};
+      MaskArrayDevice h_mad = {h_ma.data(), d_ma.num_masks_per_entry, size};
 
       std::deque<std::pair<std::size_t, std::size_t>> a;
       std::deque<std::pair<std::size_t, std::size_t>> b;
@@ -172,11 +171,9 @@ TEST(MaskArray, base) {
 TEST(MaskArray, particle_loop) {
   int npart_cell = 51;
   const int ndim = 2;
-  const int nx = 1;
-  const int ny = 1;
+  const int nx = 16;
+  const int ny = 20;
   const int nz = 48;
-
-  nprint("fix cell count");
 
   auto [A_t, sycl_target_t, cell_count_t] =
       particle_loop_create_common(npart_cell, ndim, nx, ny, nz);
@@ -184,7 +181,7 @@ TEST(MaskArray, particle_loop) {
   auto A = A_t;
   auto sycl_target = sycl_target_t;
 
-  for (std::size_t B : {1, 2, 3, 7}) {
+  for (std::size_t B : {1, 2, 3, 7, 33, 65}) {
 
     auto ma = std::make_shared<MaskArray>(sycl_target, B);
 
@@ -206,24 +203,15 @@ TEST(MaskArray, particle_loop) {
 
     particle_loop(
         A,
-        [=](auto INDEX, auto MA, auto R) {
+        [=](auto INDEX, auto MA) {
           for (std::size_t bx = 0; bx < B; bx++) {
             const bool correct = ((INDEX.cell + INDEX.layer) % (bx + 1)) == 0;
             const bool to_test = MA.get(INDEX.get_loop_linear_index(), bx);
             NESO_KERNEL_ASSERT(correct == to_test, k_ep);
-            R.at(0) = correct;
-            R.at(1) = to_test;
           }
         },
-        Access::read(ParticleLoopIndex{}), Access::write(ma),
-        Access::write(Sym<INT>("LOOP_INDEX")))
+        Access::read(ParticleLoopIndex{}), Access::read(ma))
         ->execute();
-
-    nprint("TODO MAKE READ ACCCESS DESCIPRITOR");
-
-    WHILST THIS BIT BASHINGS IS SPACE EFFICIENT IT IS NOT THREAD SAFE!
-
-    A->print(Sym<INT>("LOOP_INDEX"));
 
     ASSERT_FALSE(ep.get_flag());
   }

--- a/test/test_mask_array.cpp
+++ b/test/test_mask_array.cpp
@@ -168,3 +168,66 @@ TEST(MaskArray, base) {
   }
   sycl_target->free();
 }
+
+TEST(MaskArray, particle_loop) {
+  int npart_cell = 51;
+  const int ndim = 2;
+  const int nx = 1;
+  const int ny = 1;
+  const int nz = 48;
+
+  nprint("fix cell count");
+
+  auto [A_t, sycl_target_t, cell_count_t] =
+      particle_loop_create_common(npart_cell, ndim, nx, ny, nz);
+
+  auto A = A_t;
+  auto sycl_target = sycl_target_t;
+
+  for (std::size_t B : {1, 2, 3, 7}) {
+
+    auto ma = std::make_shared<MaskArray>(sycl_target, B);
+
+    ma->reset(false, A->get_npart_local());
+
+    particle_loop(
+        A,
+        [=](auto INDEX, auto MA) {
+          for (std::size_t bx = 0; bx < B; bx++) {
+            const bool value = ((INDEX.cell + INDEX.layer) % (bx + 1)) == 0;
+            MA.set(INDEX.get_loop_linear_index(), bx, value);
+          }
+        },
+        Access::read(ParticleLoopIndex{}), Access::write(ma))
+        ->execute();
+
+    ErrorPropagate ep(sycl_target);
+    auto k_ep = ep.device_ptr();
+
+    particle_loop(
+        A,
+        [=](auto INDEX, auto MA, auto R) {
+          for (std::size_t bx = 0; bx < B; bx++) {
+            const bool correct = ((INDEX.cell + INDEX.layer) % (bx + 1)) == 0;
+            const bool to_test = MA.get(INDEX.get_loop_linear_index(), bx);
+            NESO_KERNEL_ASSERT(correct == to_test, k_ep);
+            R.at(0) = correct;
+            R.at(1) = to_test;
+          }
+        },
+        Access::read(ParticleLoopIndex{}), Access::write(ma),
+        Access::write(Sym<INT>("LOOP_INDEX")))
+        ->execute();
+
+    nprint("TODO MAKE READ ACCCESS DESCIPRITOR");
+
+    WHILST THIS BIT BASHINGS IS SPACE EFFICIENT IT IS NOT THREAD SAFE!
+
+    A->print(Sym<INT>("LOOP_INDEX"));
+
+    ASSERT_FALSE(ep.get_flag());
+  }
+
+  sycl_target->free();
+  A->domain->mesh->free();
+}


### PR DESCRIPTION
* Adds MaskArray as a generic container for masks.
* Adds PairMask as a container, that specialises MaskArray, for enabling/disabling pairs in pair lists.
* Removes the ability to pass multiple pair lists to particle pair loops based on CellwisePairLists.